### PR TITLE
Update tests for requireFields arg order

### DIFF
--- a/tests/integration/error-handling.test.js
+++ b/tests/integration/error-handling.test.js
@@ -26,7 +26,7 @@ describe('Error Handling Integration Tests', () => {
       expect(() => utils.formatDuration(invalidDate)).toThrow();
       
       // Test validation with malformed object
-      expect(utils.requireFields(mockRes, null, ['field'])).toBe(false);
+      expect(utils.requireFields(null, ['field'], mockRes)).toBe(false); // (reordered parameters to match obj, fields, res)
       expect(mockRes.status).toHaveBeenCalledWith(500);
       
       // Test auth with malformed request
@@ -53,7 +53,7 @@ describe('Error Handling Integration Tests', () => {
       expect(utils.getRequiredHeader(malformedReq, mockRes, 'auth', 401, 'Missing')).toBeNull();
       expect(mockRes.status).toHaveBeenCalledWith(401);
       
-      expect(utils.requireFields(mockRes, malformedReq.body, ['field'])).toBe(false);
+      expect(utils.requireFields(malformedReq.body, ['field'], mockRes)).toBe(false); // (reordered parameters to match obj, fields, res)
     });
   });
 
@@ -251,7 +251,7 @@ describe('Error Handling Integration Tests', () => {
         mockRes.status.mockClear();
         mockRes.json.mockClear();
         
-        const result = utils.requireFields(mockRes, obj, fields);
+        const result = utils.requireFields(obj, fields, mockRes); // (reordered parameters to match obj, fields, res)
         expect(result).toBe(false);
         expect(mockRes.status).toHaveBeenCalledWith(expectedStatus);
       });

--- a/tests/integration/module-interactions.test.js
+++ b/tests/integration/module-interactions.test.js
@@ -82,7 +82,7 @@ describe('Module Integration Tests', () => {
       expect(isAuth).toBe(true);
       
       // Then validate required fields
-      const isValid = requireFields(mockRes, mockAuthReq.body, ['title', 'content']);
+      const isValid = requireFields(mockAuthReq.body, ['title', 'content'], mockRes); // (reordered parameters to match obj, fields, res)
       expect(isValid).toBe(true);
       expect(mockRes.status).not.toHaveBeenCalled();
     });
@@ -104,7 +104,7 @@ describe('Module Integration Tests', () => {
       expect(isAuth).toBe(false);
       
       // Fields are valid but auth failed
-      const isValid = requireFields(mockRes, mockUnauthReq.body, ['title', 'content']);
+      const isValid = requireFields(mockUnauthReq.body, ['title', 'content'], mockRes); // (reordered parameters to match obj, fields, res)
       expect(isValid).toBe(true);
     });
   });
@@ -194,7 +194,7 @@ describe('Module Integration Tests', () => {
       expect(isAuthenticated).toBe(true);
       
       // Step 2: Validate required fields
-      const fieldsValid = requireFields(mockRes, mockReq.body, ['title', 'content']);
+      const fieldsValid = requireFields(mockReq.body, ['title', 'content'], mockRes); // (reordered parameters to match obj, fields, res)
       expect(fieldsValid).toBe(true);
       
       // Step 3: Extract and validate required headers
@@ -247,7 +247,7 @@ describe('Module Integration Tests', () => {
       expect(checkPassportAuth(mockReq)).toBe(true);
       
       // Validation fails
-      const fieldsValid = requireFields(mockRes, mockReq.body, ['title', 'content']);
+      const fieldsValid = requireFields(mockReq.body, ['title', 'content'], mockRes); // (reordered parameters to match obj, fields, res)
       expect(fieldsValid).toBe(false);
       expect(mockRes.status).toHaveBeenCalledWith(400);
       expect(mockRes.json).toHaveBeenCalledWith({
@@ -272,7 +272,7 @@ describe('Module Integration Tests', () => {
       expect(checkPassportAuth(mockReq)).toBe(false);
       
       // Even though fields are valid, auth failed
-      const fieldsValid = requireFields(mockRes, mockReq.body, ['title', 'content']);
+      const fieldsValid = requireFields(mockReq.body, ['title', 'content'], mockRes); // (reordered parameters to match obj, fields, res)
       expect(fieldsValid).toBe(true);
       
       // In a real app, we'd return 401 for auth failure before validating fields

--- a/tests/unit/validation.test.js
+++ b/tests/unit/validation.test.js
@@ -15,7 +15,7 @@ describe('Validation Utilities', () => {
     // verifies should return true when all required fields are present
     test('should return true when all required fields are present', () => {
       const obj = { name: 'John', email: 'john@example.com', age: 30 };
-      const result = requireFields(mockRes, obj, ['name', 'email', 'age']);
+      const result = requireFields(obj, ['name', 'email', 'age'], mockRes);
       
       expect(result).toBe(true);
       expect(mockRes.status).not.toHaveBeenCalled();
@@ -24,7 +24,7 @@ describe('Validation Utilities', () => {
     // verifies should return false and send error for missing fields
     test('should return false and send error for missing fields', () => {
       const obj = { name: 'John', age: 30 };
-      const result = requireFields(mockRes, obj, ['name', 'email', 'age']);
+      const result = requireFields(obj, ['name', 'email', 'age'], mockRes);
       
       expect(result).toBe(false);
       expect(mockRes.status).toHaveBeenCalledWith(400);
@@ -36,7 +36,7 @@ describe('Validation Utilities', () => {
     // verifies should return false for multiple missing fields
     test('should return false for multiple missing fields', () => {
       const obj = { name: 'John' };
-      const result = requireFields(mockRes, obj, ['name', 'email', 'age']);
+      const result = requireFields(obj, ['name', 'email', 'age'], mockRes);
       
       expect(result).toBe(false);
       expect(mockRes.status).toHaveBeenCalledWith(400);
@@ -48,7 +48,7 @@ describe('Validation Utilities', () => {
     // verifies should treat falsy values as missing
     test('should treat falsy values as missing', () => {
       const obj = { name: '', email: null, age: 0, active: false };
-      const result = requireFields(mockRes, obj, ['name', 'email', 'age', 'active']);
+      const result = requireFields(obj, ['name', 'email', 'age', 'active'], mockRes);
       
       expect(result).toBe(false);
       expect(mockRes.status).toHaveBeenCalledWith(400);
@@ -60,7 +60,7 @@ describe('Validation Utilities', () => {
     // verifies should handle empty object
     test('should handle empty object', () => {
       const obj = {};
-      const result = requireFields(mockRes, obj, ['name']);
+      const result = requireFields(obj, ['name'], mockRes);
       
       expect(result).toBe(false);
       expect(mockRes.status).toHaveBeenCalledWith(400);
@@ -69,7 +69,7 @@ describe('Validation Utilities', () => {
     // verifies should handle empty required fields array
     test('should handle empty required fields array', () => {
       const obj = { name: 'John' };
-      const result = requireFields(mockRes, obj, []);
+      const result = requireFields(obj, [], mockRes);
       
       expect(result).toBe(true);
       expect(mockRes.status).not.toHaveBeenCalled();
@@ -77,7 +77,7 @@ describe('Validation Utilities', () => {
 
     // verifies should handle undefined object gracefully
     test('should handle undefined object gracefully', () => {
-      const result = requireFields(mockRes, undefined, ['name']);
+      const result = requireFields(undefined, ['name'], mockRes);
       
       expect(result).toBe(false);
       expect(mockRes.status).toHaveBeenCalledWith(500);
@@ -88,7 +88,7 @@ describe('Validation Utilities', () => {
 
     // verifies should handle null object gracefully
     test('should handle null object gracefully', () => {
-      const result = requireFields(mockRes, null, ['name']);
+      const result = requireFields(null, ['name'], mockRes);
       
       expect(result).toBe(false);
       expect(mockRes.status).toHaveBeenCalledWith(500);
@@ -103,7 +103,7 @@ describe('Validation Utilities', () => {
         data: ['item'], 
         config: { setting: 'value' } 
       };
-      const result = requireFields(mockRes, obj, ['name', 'count', 'active', 'data', 'config']);
+      const result = requireFields(obj, ['name', 'count', 'active', 'data', 'config'], mockRes);
       
       expect(result).toBe(true);
       expect(mockRes.status).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- fix requireFields parameter order in integration and unit tests
- verify test suite execution

## Testing
- `npm test` *(fails: Validation Utilities › requireFields › should return false and send error for missing fields, others)*

------
https://chatgpt.com/codex/tasks/task_b_6846731f12488322bfb89e96032dbb42