### PR TITLE
Add test setup script and CI

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -1,0 +1,22 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
+    - name: Install dependencies
+      run: npm ci
+    - name: Run tests
+      run: npm test

--- a/README.md
+++ b/README.md
@@ -225,11 +225,10 @@ The library is organized into focused modules:
 
 ## Testing
 
-Install dependencies with `npm install` before running tests.
-
-Run the comprehensive test suite:
+Install all dependencies with the helper script before running tests:
 
 ```bash
+sh scripts/setup-tests.sh
 npm test
 ```
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A comprehensive utility library providing datetime formatting, HTTP helpers, URL manipulation, authentication checks, field validation, and view rendering with robust error handling",
   "main": "index.js",
   "scripts": {
+    "setup-tests": "sh scripts/setup-tests.sh",
     "test": "node tests/run-tests.js",
     "test:watch": "node tests/run-tests.js --watch",
     "test:coverage": "node tests/run-tests.js --coverage",

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Setup script to install test dependencies before running the test suite
+# Runs npm install to ensure devDependencies are available
+
+npm install


### PR DESCRIPTION
## Summary
- add script to install dev dependencies before running tests
- document test setup in README
- add `setup-tests` npm script
- configure basic GitHub Actions workflow for test runs

## Testing
- `sh scripts/setup-tests.sh`
- `npm test` *(fails: "Tests failed with exit code 1")*

------
https://chatgpt.com/codex/tasks/task_b_68479dda4b288322bb8194c6783def60