### PR TITLE
Improve test coverage

### DIFF
--- a/tests/unit/additional-edge-cases.test.js
+++ b/tests/unit/additional-edge-cases.test.js
@@ -1,0 +1,43 @@
+const httpUtils = require('../../lib/http');
+const urlUtils = require('../../lib/url');
+const { qerrors } = require('qerrors');
+
+describe('Additional Edge Cases', () => {
+  describe('calculateContentLength', () => {
+    test('should return 0 for boolean body', () => {
+      expect(httpUtils.calculateContentLength(true)).toBe('0');
+    });
+  });
+
+  describe('buildCleanHeaders', () => {
+    test('should return empty object when headers not object', () => {
+      const result = httpUtils.buildCleanHeaders('bad', 'GET', null);
+      expect(result).toEqual({});
+    });
+
+    test('should return original headers on error', () => {
+      const circular = {};
+      circular.self = circular; // create JSON.stringify failure case
+      const headers = { 'content-type': 'application/json' };
+      const result = httpUtils.buildCleanHeaders(headers, 'POST', circular);
+      expect(qerrors).toHaveBeenCalled();
+      expect(result).toBe(headers);
+    });
+  });
+
+  describe('stripProtocol', () => {
+    test('should return input when not string and log error', () => {
+      const result = urlUtils.stripProtocol(null);
+      expect(qerrors).toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('parseUrlParts', () => {
+    test('should return null for malformed url with protocol only', () => {
+      const result = urlUtils.parseUrlParts('http://');
+      expect(qerrors).toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/tests/unit/logging-utils.test.js
+++ b/tests/unit/logging-utils.test.js
@@ -1,0 +1,51 @@
+const { logFunctionStart, logFunctionResult, logFunctionError } = require('../../lib/logging-utils');
+const { qerrors } = require('qerrors');
+
+describe('Logging Utilities', () => {
+  describe('logFunctionStart', () => {
+    test('should log string input', () => {
+      logFunctionStart('testStart', 'value');
+      expect(mockConsole.log).toHaveBeenCalledWith('testStart is running with value');
+    });
+
+    test('should log null input', () => {
+      logFunctionStart('testStart', null);
+      expect(mockConsole.log).toHaveBeenCalledWith('testStart is running with null');
+    });
+
+    test('should log object input', () => {
+      const obj = { a: 1 };
+      logFunctionStart('testStart', obj);
+      expect(mockConsole.log).toHaveBeenCalledWith(`testStart is running with ${JSON.stringify(obj)}`);
+    });
+  });
+
+  describe('logFunctionResult', () => {
+    test('should log undefined result', () => {
+      logFunctionResult('testResult', undefined);
+      expect(mockConsole.log).toHaveBeenCalledWith('testResult is returning undefined');
+    });
+
+    test('should log object result', () => {
+      const obj = { b: 2 };
+      logFunctionResult('testResult', obj);
+      expect(mockConsole.log).toHaveBeenCalledWith(`testResult is returning ${JSON.stringify(obj)}`);
+    });
+  });
+
+  describe('logFunctionError', () => {
+    test('should log error and return false by default', () => {
+      const err = new Error('fail');
+      const result = logFunctionError(err, 'testError', { ctx: true });
+      expect(qerrors).toHaveBeenCalledWith(err, 'testError', { ctx: true });
+      expect(mockConsole.log).toHaveBeenCalledWith('testError has run resulting in a final value of failure');
+      expect(result).toBe(false);
+    });
+
+    test('should support custom default return', () => {
+      const err = new Error('oops');
+      const result = logFunctionError(err, 'testError', {}, 'fallback');
+      expect(result).toBe('fallback');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for logging utilities
- cover edge cases across HTTP and URL modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684942d463548322802001e3d173cc26