### PR TITLE
Trim URL input in ensureProtocol

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -75,13 +75,15 @@ function ensureProtocol(url) {
       return null; // Return null to signal invalid input to caller
     }
 
+    const trimmedUrl = url.trim(); // Remove leading/trailing spaces to normalize input
+
     // Handle empty or invalid input gracefully - return null for missing URLs
-    if (!url || url.trim().length === 0) {
+    if (trimmedUrl.length === 0) {
       console.log(`ensureProtocol is returning null`); // Log fallback for empty input
       return null; // Indicate invalid/missing URL input
     }
 
-    let finalUrl = url; // Work with copy to avoid mutating input
+    let finalUrl = trimmedUrl; // Work with sanitized copy to avoid mutating input
 
     // Check if protocol is already present using centralized detection
     if (!hasProtocol(finalUrl)) { 

--- a/tests/unit/url.test.js
+++ b/tests/unit/url.test.js
@@ -52,6 +52,11 @@ describe('URL Utilities', () => {
     test('should handle URLs with query parameters', () => {
       expect(ensureProtocol('example.com/path?q=test')).toBe('https://example.com/path?q=test');
     });
+
+    // verifies should trim whitespace and add https
+    test('should trim whitespace and add https', () => {
+      expect(ensureProtocol('  example.com  ')).toBe('https://example.com');
+    });
   });
 
   describe('normalizeUrlOrigin', () => {


### PR DESCRIPTION
## Summary
- trim input for `ensureProtocol` to remove stray spaces
- test whitespace trimming for URL normalization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6849dbef53d48322b89a5493fd24395b