### PR TITLE
Handle unserializable logging

### DIFF
--- a/lib/logging-utils.js
+++ b/lib/logging-utils.js
@@ -29,10 +29,13 @@ const { qerrors } = require('qerrors'); // internal error logger
  * @param {*} input - Input parameter(s) being processed
  */
 function logFunctionStart(functionName, input) {
-  const inputDisplay = input === null ? 'null' : 
-                      input === undefined ? 'undefined' :
-                      typeof input === 'object' ? JSON.stringify(input) :
-                      String(input);
+  let inputDisplay; // store stringified input or fallback
+  if (input === null) { inputDisplay = 'null'; } // handle explicit null
+  else if (input === undefined) { inputDisplay = 'undefined'; } // handle undefined
+  else if (typeof input === 'object') {
+    try { inputDisplay = JSON.stringify(input); } // stringify object input
+    catch (err) { qerrors(err, 'logFunctionStart', { input }); inputDisplay = '[unserializable]'; } // placeholder for bad serialization
+  } else { inputDisplay = String(input); } // convert primitive values
   console.log(`${functionName} is running with ${inputDisplay}`);
 }
 
@@ -47,10 +50,13 @@ function logFunctionStart(functionName, input) {
  * @param {*} result - Return value being logged
  */
 function logFunctionResult(functionName, result) {
-  const resultDisplay = result === null ? 'null' : 
-                       result === undefined ? 'undefined' :
-                       typeof result === 'object' ? JSON.stringify(result) :
-                       String(result);
+  let resultDisplay; // store stringified result or fallback
+  if (result === null) { resultDisplay = 'null'; } // handle explicit null
+  else if (result === undefined) { resultDisplay = 'undefined'; } // handle undefined
+  else if (typeof result === 'object') {
+    try { resultDisplay = JSON.stringify(result); } // stringify object result
+    catch (err) { qerrors(err, 'logFunctionResult', { result }); resultDisplay = '[unserializable]'; } // placeholder on error
+  } else { resultDisplay = String(result); } // convert primitive values
   console.log(`${functionName} is returning ${resultDisplay}`);
 }
 

--- a/tests/unit/logging-utils.test.js
+++ b/tests/unit/logging-utils.test.js
@@ -18,6 +18,13 @@ describe('Logging Utilities', () => {
       logFunctionStart('testStart', obj);
       expect(mockConsole.log).toHaveBeenCalledWith(`testStart is running with ${JSON.stringify(obj)}`);
     });
+
+    test('should handle circular reference input', () => {
+      const circ = {}; circ.self = circ; // create circular object for test
+      logFunctionStart('testStart', circ); // call with circular object
+      expect(mockConsole.log).toHaveBeenCalledWith('testStart is running with [unserializable]');
+      expect(qerrors).toHaveBeenCalledWith(expect.any(Error), 'logFunctionStart', { input: circ });
+    });
   });
 
   describe('logFunctionResult', () => {
@@ -30,6 +37,13 @@ describe('Logging Utilities', () => {
       const obj = { b: 2 };
       logFunctionResult('testResult', obj);
       expect(mockConsole.log).toHaveBeenCalledWith(`testResult is returning ${JSON.stringify(obj)}`);
+    });
+
+    test('should handle circular reference result', () => {
+      const circ = {}; circ.self = circ; // create circular object result
+      logFunctionResult('testResult', circ); // call with circular object
+      expect(mockConsole.log).toHaveBeenCalledWith('testResult is returning [unserializable]');
+      expect(qerrors).toHaveBeenCalledWith(expect.any(Error), 'logFunctionResult', { result: circ });
     });
   });
 


### PR DESCRIPTION
## Summary
- handle JSON.stringify failures in `logFunctionStart` and `logFunctionResult`
- add tests for circular reference inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6849dbf0ad988322b4bfe00b1cec2d44