### PR TITLE
Handle Buffer input in content length

### DIFF
--- a/API.md
+++ b/API.md
@@ -120,6 +120,7 @@ Calculate accurate byte length for HTTP bodies with UTF-8 support.
 - `string`: Uses `Buffer.byteLength()` for UTF-8 accuracy
 - `object`: JSON stringifies then calculates bytes
 - Empty objects/strings: Returns "0"
+- `Buffer`: Uses body.length directly for binary payloads // Buffer bullet
 
 **Example:**
 ```javascript
@@ -128,6 +129,7 @@ const { calculateContentLength } = require('qgenutils');
 calculateContentLength("Hello, 世界!"); // "13" (UTF-8 bytes)
 calculateContentLength({ msg: "hi" }); // "12" (JSON bytes)
 calculateContentLength(null); // "0"
+calculateContentLength(Buffer.from('Hi')); // "2" (binary bytes) // Buffer example
 ```
 
 ### `buildCleanHeaders(headers, method, body)`

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ const { calculateContentLength } = require('qgenutils');
 console.log(calculateContentLength('Hello World')); // 11
 console.log(calculateContentLength({ name: 'John' })); // JSON string length
 console.log(calculateContentLength(null)); // 0
+console.log(calculateContentLength(Buffer.from('Hi'))); // 2 // Buffer example
 ```
 
 #### `buildCleanHeaders(headers, method, body)`

--- a/USAGE.md
+++ b/USAGE.md
@@ -116,6 +116,10 @@ const length = calculateContentLength(textBody);
 const jsonBody = { message: "Hello" };
 const jsonLength = calculateContentLength(jsonBody);
 // Returns: "20" (JSON.stringify byte length)
+
+const buf = Buffer.from('Hi');
+const bufLength = calculateContentLength(buf);
+// Returns: "2" (binary length) // Buffer example
 ```
 
 ### `buildCleanHeaders(headers, method, body)`

--- a/lib/http.js
+++ b/lib/http.js
@@ -67,7 +67,7 @@ const HEADERS_TO_REMOVE = [
  * 
  * IMPLEMENTATION DECISIONS:
  * - Use Buffer.byteLength() for accurate UTF-8 byte counting (not character count)
- * - Handle various input types (string, object, null, empty)
+ * - Handle various input types (string, object, Buffer, null, empty) // added Buffer for binary support
  * - Distinguish between undefined (error) and empty content (zero length)
  * - Return string format as HTTP headers must be strings
  * 
@@ -76,6 +76,7 @@ const HEADERS_TO_REMOVE = [
  * - Null input (returns '0' - valid empty body)
  * - Empty string (returns '0' - valid empty body)
  * - Empty object (returns '0' - valid empty JSON)
+ * - Buffer input (returns body.length - byte accurate) // new edge case
  * - Unicode characters (accurate byte counting)
  * 
  * WHY NOT String.length:
@@ -108,6 +109,13 @@ function calculateContentLength(body) {
       const len = Buffer.byteLength(body, 'utf8'); // Accurate UTF-8 byte counting
       console.log(`calculateContentLength is returning ${len}`);
       return len.toString();
+    }
+
+    // Handle Buffer bodies - binary payloads
+    if (Buffer.isBuffer(body)) { // check for Node Buffer
+      const len = body.length; // Buffer length equals byte size
+      console.log(`calculateContentLength is returning ${len}`); // log for debugging
+      return len.toString(); // return as string per HTTP spec
     }
 
     // Handle object bodies - JSON APIs

--- a/tests/unit/http.test.js
+++ b/tests/unit/http.test.js
@@ -55,6 +55,12 @@ describe('HTTP Utilities', () => {
       const expected = Buffer.byteLength(JSON.stringify(complexObj), 'utf8').toString();
       expect(calculateContentLength(complexObj)).toBe(expected);
     });
+
+    // verifies should calculate length for Buffer body
+    test('should calculate length for Buffer body', () => {
+      const buf = Buffer.from('abc');
+      expect(calculateContentLength(buf)).toBe(buf.length.toString());
+    });
   });
 
   describe('buildCleanHeaders', () => {


### PR DESCRIPTION
## Summary
- handle Buffer instances in calculateContentLength
- document Buffer example in README, API, and USAGE guides
- test calculateContentLength with Buffer body

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6849dbf162088322b6c0508223bc8da2