### PR TITLE
Fix header utilities

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -170,7 +170,12 @@ function calculateContentLength(body) {
  * @returns {object} Cleaned headers object safe for forwarding
  */
 function buildCleanHeaders(headers, method, body) {
-    console.log(`buildCleanHeaders is running with ${method}`); // Log method for debugging header logic
+    // Normalize method to lower case or default to 'get' if invalid
+    let safeMethod = 'get'; // default for undefined or invalid method
+    if (typeof method === 'string' && method.trim()) {
+        safeMethod = method.toLowerCase();
+    }
+    console.log(`buildCleanHeaders is running with ${safeMethod}`); // Log normalized method for debugging header logic
     try {
         // Validate headers parameter - return original value for null/undefined
         if (headers === null) {
@@ -197,14 +202,14 @@ function buildCleanHeaders(headers, method, body) {
         // Handle content-length based on method and body presence
         // GET requests should never have content-length, even if originally present
         // This prevents HTTP/1.1 spec violations and upstream server confusion
-        if (!body || method.toLowerCase() === 'get') {
+        if (!body || safeMethod === 'get') {
             delete cleanHeaders['content-length']; // Ensure GET requests have no content-length
         }
 
         // For non-GET requests with actual body content, set accurate content-length
         // We check for body existence and handle both string and object types properly
         // This prevents setting content-length: 0 for requests that legitimately have no body
-        if (method.toLowerCase() !== 'get' && body) {
+        if (safeMethod !== 'get' && body) {
             // Handle string bodies (most common case)
             if (typeof body === 'string' && body.length > 0) {
                 cleanHeaders['content-length'] = calculateContentLength(body);
@@ -220,7 +225,7 @@ function buildCleanHeaders(headers, method, body) {
     } catch (error) {
         // Log error but return original headers as fallback
         // This prevents complete request failure due to header cleaning issues
-        qerrors(error, 'buildCleanHeaders', { method });
+        qerrors(error, 'buildCleanHeaders', { method: safeMethod }); // log normalized method to aid debugging
         return headers; // Fallback to original headers if cleaning fails
     }
 }
@@ -257,11 +262,12 @@ function buildCleanHeaders(headers, method, body) {
  * @returns {string|null} The header value or null if missing/error
  */
 function getRequiredHeader(req, res, headerName, statusCode, errorMessage) {
-  console.log(`getRequiredHeader is running with ${headerName}`); // Log header extraction attempt
+  const normalizedName = typeof headerName === 'string' ? headerName.toLowerCase() : ''; // lower-case for reliable lookup
+  console.log(`getRequiredHeader is running with ${normalizedName}`); // Log normalized header extraction attempt
   try {
     // Safely access header value even if headers object is undefined
     // Express normalizes header names to lowercase, so this handles case variations
-    const headerValue = req?.headers?.[headerName];
+    const headerValue = req?.headers?.[normalizedName];
 
     if (!headerValue) {
       // Send appropriate error response based on status code
@@ -278,7 +284,7 @@ function getRequiredHeader(req, res, headerName, statusCode, errorMessage) {
     return headerValue;
   } catch (error) {
     // Handle unexpected errors in header processing
-    qerrors(error, 'getRequiredHeader', { headerName, statusCode, errorMessage });
+    qerrors(error, 'getRequiredHeader', { headerName: normalizedName, statusCode, errorMessage }); // log normalized name for consistency
     sendServerError(res, 'Internal server error', error, 'getRequiredHeader');
     return null; // Signal failure to calling code
   }

--- a/tests/unit/http.test.js
+++ b/tests/unit/http.test.js
@@ -119,6 +119,13 @@ describe('HTTP Utilities', () => {
       buildCleanHeaders(originalHeaders, 'GET', null);
       expect(originalHeaders).toEqual(original);
     });
+
+    // verifies should default to GET when method is invalid
+    test('should default to GET when method is invalid', () => {
+      const result = buildCleanHeaders(originalHeaders, 123, null);
+      expect(result['content-length']).toBeUndefined();
+      expect(result['host']).toBeUndefined();
+    });
   });
 
   describe('sendJsonResponse', () => {
@@ -196,9 +203,15 @@ describe('HTTP Utilities', () => {
     test('should handle undefined headers', () => {
       const reqWithoutHeaders = { headers: undefined };
       const result = getRequiredHeader(reqWithoutHeaders, mockRes, 'authorization', 401, 'Missing auth');
-      
+
       expect(result).toBeNull();
       expect(mockRes.status).toHaveBeenCalledWith(401);
+    });
+
+    // verifies should retrieve header regardless of case
+    test('should retrieve header regardless of case', () => {
+      const result = getRequiredHeader(mockReq, mockRes, 'Authorization', 401, 'Missing auth');
+      expect(result).toBe('Bearer token123');
     });
 
     // verifies should handle errors during header processing


### PR DESCRIPTION
## Summary
- validate HTTP method before cleaning headers
- default to GET for invalid methods
- lookup headers using lowercase name
- test invalid method and mixed-case header retrieval

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6849f9544f248322afa796aca4957c1f