### PR TITLE
Fix renderView missing send check

### DIFF
--- a/lib/views.js
+++ b/lib/views.js
@@ -86,7 +86,7 @@ function renderView(res, viewName, errorTitle) {
 
     // Send user-friendly error page with helpful information if res is available
     // This prevents users from seeing cryptic error messages or blank pages
-    if (hasMethod(res, 'status')) {
+    if (hasMethod(res, 'status') && hasMethod(res, 'send')) { // ensure error page methods exist
       res.status(500).send(`
         <h1>${errorTitle}</h1>
         <p>There was an error rendering the ${viewName} page:</p>

--- a/tests/unit/views.test.js
+++ b/tests/unit/views.test.js
@@ -41,6 +41,22 @@ describe('View Utilities', () => {
       expect(mockRes.send).toHaveBeenCalledWith(expect.stringContaining('Return to Home'));
     });
 
+    // verifies should handle missing send method gracefully
+    test('should handle missing send method gracefully', () => {
+      const error = new Error('Render fails');
+      mockRes.render.mockImplementation(() => {
+        throw error;
+      });
+
+      delete mockRes.send; // simulate missing send method
+
+      expect(() => {
+        renderView(mockRes, 'view', 'Error Title');
+      }).not.toThrow();
+
+      expect(mockRes.status).not.toHaveBeenCalled();
+    });
+
     // verifies should include error message in error page
     test('should include error message in error page', () => {
       const error = new Error('Custom error message');


### PR DESCRIPTION
## Summary
- ensure renderView validates both status and send methods
- add test covering missing send method on `res`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6849f9593ae88322883740f82c7a8c94