### PR TITLE
Remove outdated module import example

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -9,10 +9,7 @@ npm install qgenutils
 ## Quick Start
 
 ```javascript
-const QGenUtils = require('qgenutils');
-
-// Or import specific modules
-const { auth, validation, datetime } = require('qgenutils');
+const QGenUtils = require('qgenutils'); // import all utilities
 
 // Or import individual functions
 const { checkPassportAuth, requireFields, formatDateTime } = require('qgenutils');


### PR DESCRIPTION
## Summary
- update USAGE.md quick start section to remove the stale module import example and demonstrate importing functions directly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6849f95c79b483229ec3a70e25bc13ca