### PR TITLE
Fix github strategy check

### DIFF
--- a/API.md
+++ b/API.md
@@ -48,6 +48,7 @@ Detect if GitHub OAuth strategy is configured in Passport.js.
 ```javascript
 const { hasGithubStrategy } = require('qgenutils');
 
+// hasGithubStrategy checks global.passport for configured strategies
 const showGithubLogin = hasGithubStrategy();
 ```
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Checks if GitHub OAuth strategy is configured.
 ```javascript
 const { hasGithubStrategy } = require('qgenutils');
 
+// hasGithubStrategy reads global.passport to detect configuration
 if (hasGithubStrategy()) {
   // Show GitHub login button
 }

--- a/USAGE.md
+++ b/USAGE.md
@@ -48,6 +48,7 @@ const { hasGithubStrategy } = require('qgenutils');
 app.get('/login-options', (req, res) => {
   const loginMethods = {
     local: true,
+    // hasGithubStrategy reads global.passport to detect GitHub OAuth setup
     github: hasGithubStrategy()
   };
   

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -125,16 +125,13 @@ function checkPassportAuth(req) {
  */
 function hasGithubStrategy() {
   try {
-    // Handle case where passport is not defined or available
-    if (typeof passport === 'undefined') {
-      logAuthOperation('hasGithubStrategy', 'none', false);
-      return false; // No passport means no GitHub strategy
+    const passportObj = global.passport; // grab passport instance from global to avoid undeclared variable usage
+    if (!passportObj || !passportObj._strategies) { // ensure passport and strategies exist before checking
+      logAuthOperation('hasGithubStrategy', 'none', false); // log fail state when prerequisites missing
+      return false; // fail closed if passport or strategies missing
     }
 
-    // Check if the GitHub strategy is configured in Passport
-    // Strategy names are typically stored in passport._strategies
-    const hasStrategy = passport && passport._strategies && passport._strategies['github'];
-    const result = !!hasStrategy; // Convert to boolean (true if strategy exists)
+    const result = !!passportObj._strategies['github']; // true if github strategy configured
     
     logAuthOperation('hasGithubStrategy', 'none', result);
     return result;

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -152,7 +152,22 @@ describe('Authentication Utilities', () => {
           throw new Error('Access error');
         }
       };
-      
+
+      expect(hasGithubStrategy()).toBe(false);
+    });
+
+    // verifies should ignore local passport variable when global.passport is undefined
+    test('should ignore local passport variable when global.passport is undefined', () => {
+      const passport = { _strategies: { github: {} } }; // local variable with strategy
+      global.passport = undefined; // global remains undefined
+
+      expect(hasGithubStrategy()).toBe(false);
+    });
+
+    // verifies should return false when _strategies is not an object
+    test('should return false when _strategies is not an object', () => {
+      global.passport = { _strategies: 'invalid' };
+
       expect(hasGithubStrategy()).toBe(false);
     });
   });


### PR DESCRIPTION
## Summary
- ensure `hasGithubStrategy` references `global.passport`
- make docs describe that auth utilities read `global.passport`
- test ignoring local `passport` variable and invalid `_strategies`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684a757ee64883229f926864435fb751