### PR TITLE
Fix usage doc header cleanup example

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -122,20 +122,20 @@ const bufLength = calculateContentLength(buf);
 
 ### `buildCleanHeaders(headers, method, body)`
 
-Remove dangerous headers and recalculate content-length for proxy security.
+Remove dangerous headers (for example `host` and `x-target-url`) and recalculate content-length for proxy security.
 
 ```javascript
 const { buildCleanHeaders } = require('qgenutils');
 
 const originalHeaders = {
   'host': 'example.com',
-  'x-forwarded-for': '192.168.1.1',
+  'x-target-url': 'https://backend.internal', // will be removed
   'content-length': '100',
   'authorization': 'Bearer token123'
 };
 
 const cleanHeaders = buildCleanHeaders(originalHeaders, 'POST', { data: 'test' });
-// Returns headers without 'host' and 'x-forwarded-for', with recalculated content-length
+// Returns headers without 'host' and 'x-target-url', with recalculated content-length
 ```
 
 **Security Features:**


### PR DESCRIPTION
## Summary
- tweak buildCleanHeaders example to show x-target-url is stripped
- note in explanatory text that host and x-target-url are removed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684a848941408322adf7f2e2e23b5364