### PR TITLE
Handle empty body content-length in http

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -200,22 +200,28 @@ function buildCleanHeaders(headers, method, body) {
         });
 
         // Handle content-length based on method and body presence
-        // GET requests should never have content-length, even if originally present
-        // This prevents HTTP/1.1 spec violations and upstream server confusion
-        if (!body || safeMethod === 'get') {
-            delete cleanHeaders['content-length']; // Ensure GET requests have no content-length
+        // GET or empty-body requests should never include content-length
+        // Empty bodies include empty objects and zero-length buffers
+        const emptyObj = typeof body === 'object' && body !== null && !Buffer.isBuffer(body) && Object.keys(body).length === 0; // check for {}
+        const emptyBuf = Buffer.isBuffer(body) && body.length === 0; // check for Buffer.alloc(0)
+        if (!body || emptyObj || emptyBuf || safeMethod === 'get') {
+            delete cleanHeaders['content-length']; // Ensure GET or empty body requests have no content-length
         }
 
         // For non-GET requests with actual body content, set accurate content-length
-        // We check for body existence and handle both string and object types properly
+        // Skip when body is empty object or zero-length buffer
         // This prevents setting content-length: 0 for requests that legitimately have no body
-        if (safeMethod !== 'get' && body) {
+        if (safeMethod !== 'get' && body && !emptyObj && !emptyBuf) {
             // Handle string bodies (most common case)
             if (typeof body === 'string' && body.length > 0) {
                 cleanHeaders['content-length'] = calculateContentLength(body);
             }
             // Handle object bodies (JSON APIs) - check if object has properties
-            else if (typeof body === 'object' && body !== null && Object.keys(body).length > 0) {
+            else if (typeof body === 'object' && body !== null && !Buffer.isBuffer(body) && Object.keys(body).length > 0) {
+                cleanHeaders['content-length'] = calculateContentLength(body);
+            }
+            // Handle Buffer bodies with actual content
+            else if (Buffer.isBuffer(body) && body.length > 0) {
                 cleanHeaders['content-length'] = calculateContentLength(body);
             }
         }

--- a/tests/unit/http.test.js
+++ b/tests/unit/http.test.js
@@ -107,6 +107,20 @@ describe('HTTP Utilities', () => {
       expect(result['content-length']).toBeUndefined();
     });
 
+    // verifies should remove content-length when body is empty object
+    test('should remove content-length when body is empty object', () => {
+      const input = { 'content-length': '10' };
+      const result = buildCleanHeaders(input, 'POST', {});
+      expect(result['content-length']).toBeUndefined();
+    });
+
+    // verifies should remove content-length when body is empty buffer
+    test('should remove content-length when body is empty buffer', () => {
+      const input = { 'content-length': '5' };
+      const result = buildCleanHeaders(input, 'POST', Buffer.alloc(0));
+      expect(result['content-length']).toBeUndefined();
+    });
+
     // verifies should handle empty headers object
     test('should handle empty headers object', () => {
       const result = buildCleanHeaders({}, 'GET', null);


### PR DESCRIPTION
## Summary
- prevent content-length header for empty object or Buffer bodies
- test header cleanup for empty object body
- test header cleanup for empty Buffer body

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684b56bf29d883229cd97d103584b7b8