### PR TITLE
Expose error response helpers

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@
 // Each require() statement pulls in a focused set of related functionality
 const { formatDateTime, formatDuration } = require('./lib/datetime'); // date formatting helpers
 const { calculateContentLength, buildCleanHeaders, getRequiredHeader } = require('./lib/http'); // HTTP header and length utilities
-const { sendJsonResponse } = require('./lib/response-utils'); // standardized JSON responses
+const { sendJsonResponse, sendValidationError, sendAuthError, sendServerError } = require('./lib/response-utils'); // import additional response helpers for centralized error handling
 const { requireFields } = require('./lib/validation'); // request field validation
 const { checkPassportAuth, hasGithubStrategy } = require('./lib/auth'); // Passport.js helpers
 const { ensureProtocol, normalizeUrlOrigin, stripProtocol, parseUrlParts } = require('./lib/url'); // URL normalization helpers
@@ -51,6 +51,9 @@ module.exports = {
   calculateContentLength, // expose content-length calculation
   buildCleanHeaders, // expose header sanitization logic
   sendJsonResponse, // expose JSON response helper
+  sendValidationError, // expose validation error helper for consistency
+  sendAuthError, // expose auth error helper to centralize 401 responses
+  sendServerError, // expose server error helper for unified 500 handling
   getRequiredHeader, // expose header validation helper
   
   // URL utilities - handle protocol normalization and URL parsing

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../index'); // expose library entry point to unit tests

--- a/tests/unit/index.exports.test.js
+++ b/tests/unit/index.exports.test.js
@@ -1,0 +1,11 @@
+// Unit tests verifying top-level exports from index.js are accessible
+const indexExports = require('../index');
+
+describe('Index Exports', () => {
+  // verifies should include new response utility exports
+  test('should include new response utility exports', () => {
+    expect(indexExports.sendValidationError).toBeDefined();
+    expect(indexExports.sendAuthError).toBeDefined();
+    expect(indexExports.sendServerError).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- export sendValidationError/sendAuthError/sendServerError via index
- provide tests verifying index exports
- map tests to root index with tests/index.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684b56c4db58832287867c53d0080640