### PR TITLE
Freeze HEADERS_TO_REMOVE

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -54,6 +54,7 @@ const HEADERS_TO_REMOVE = [
     'render-proxy-ttl',  // Render.com-specific proxy header
     'connection'         // HTTP/1.1 connection management header
 ];
+Object.freeze(HEADERS_TO_REMOVE); // ensure list can't be mutated at runtime
 
 /**
  * Calculate the content length of a body in bytes

--- a/tests/unit/http.test.js
+++ b/tests/unit/http.test.js
@@ -2,7 +2,7 @@
 // Unit tests for HTTP helpers covering header sanitization, content-length
 // calculations, and generic response handling to guarantee consistent behavior
 // for API proxying scenarios.
-const { calculateContentLength, buildCleanHeaders, getRequiredHeader } = require('../../lib/http');
+const { calculateContentLength, buildCleanHeaders, getRequiredHeader, HEADERS_TO_REMOVE } = require('../../lib/http'); // include constant for immutability tests
 const { sendJsonResponse } = require('../../lib/response-utils');
 
 describe('HTTP Utilities', () => {
@@ -242,6 +242,15 @@ describe('HTTP Utilities', () => {
       expect(result).toBeNull();
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' });
+    });
+  });
+
+  describe('HEADERS_TO_REMOVE', () => {
+    // verifies should not change when modification is attempted
+    test('should not change when modification is attempted', () => {
+      const original = [...HEADERS_TO_REMOVE]; // capture original list for comparison
+      expect(() => { HEADERS_TO_REMOVE.push('new-header'); }).toThrow(TypeError); // frozen array should throw on push
+      expect(HEADERS_TO_REMOVE).toEqual(original); // array should remain unchanged
     });
   });
 });


### PR DESCRIPTION
## Summary
- freeze `HEADERS_TO_REMOVE` to keep header list immutable
- test immutability of the header list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684bbea5f8cc8322ba3b2a2c8008eb0c