### PR TITLE
Update JSON response helper

### DIFF
--- a/lib/response-utils.js
+++ b/lib/response-utils.js
@@ -48,12 +48,14 @@ function sendJsonResponse(res, statusCode, data) {
   }
   
   try {
-    res.status(statusCode).json(data);
+    res.status(statusCode); // set status code without relying on chaining
+    res.json(data); // send JSON payload separately for non-chainable res objects
   } catch (error) {
     qerrors(error, 'sendJsonResponse', { statusCode, data });
     // If JSON serialization fails, try to send a basic error response
     try {
-      res.status(500).json({ error: 'Response serialization failed' });
+      res.status(500); // ensure status is set even if chaining unsupported
+      res.json({ error: 'Response serialization failed' }); // send fallback payload
     } catch (fallbackError) {
       qerrors(fallbackError, 'sendJsonResponse_fallback', { statusCode, data });
     }

--- a/tests/unit/response-utils.test.js
+++ b/tests/unit/response-utils.test.js
@@ -32,6 +32,15 @@ describe('Response Utilities', () => {
 
       expect(qerrors).toHaveBeenCalled();
     });
+
+    // verifies should work when status does not chain
+    test('should send JSON even if status does not return this', () => {
+      const nonChainRes = { status: jest.fn(), json: jest.fn().mockReturnThis() };
+      sendJsonResponse(nonChainRes, 202, { done: true });
+
+      expect(nonChainRes.status).toHaveBeenCalledWith(202);
+      expect(nonChainRes.json).toHaveBeenCalledWith({ done: true });
+    });
   });
 
   describe('sendValidationError', () => {


### PR DESCRIPTION
## Summary
- refactor `sendJsonResponse` to avoid reliance on chained `status` call
- keep fallback logic with separated status and json calls
- verify response works when `status` does not return `this`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684bbec2f3148322930aaa5b4a48754d