### PR TITLE
Fix HTML escaping in view error output

### DIFF
--- a/lib/views.js
+++ b/lib/views.js
@@ -87,10 +87,15 @@ function renderView(res, viewName, errorTitle) {
     // Send user-friendly error page with helpful information if res is available
     // This prevents users from seeing cryptic error messages or blank pages
     if (hasMethod(res, 'status') && hasMethod(res, 'send')) { // ensure error page methods exist
+      const sanitizedMessage = err.message
+        .replace(/&/g, '&amp;') // escape ampersand to prevent HTML entity issues
+        .replace(/</g, '&lt;') // escape opening angle bracket to block tags
+        .replace(/>/g, '&gt;'); // escape closing angle bracket to block tags
+
       res.status(500).send(`
         <h1>${errorTitle}</h1>
         <p>There was an error rendering the ${viewName} page:</p>
-        <pre>${err.message}</pre>
+        <pre>${sanitizedMessage}</pre>
         <p>Please contact support if this error persists.</p>
         <p><a href="/">Return to Home</a></p>
       `); // include navigation link for user convenience

--- a/tests/unit/views.test.js
+++ b/tests/unit/views.test.js
@@ -72,6 +72,19 @@ describe('View Utilities', () => {
       expect(sentContent).toContain('failing-view');
     });
 
+    // verifies should escape error message for safe HTML
+    test('should escape error message containing HTML', () => {
+      const error = new Error('<script>alert("x")</script>');
+      mockRes.render.mockImplementation(() => {
+        throw error;
+      });
+
+      renderView(mockRes, 'script-view', 'Script Error');
+
+      const sentContent = mockRes.send.mock.calls[0][0];
+      expect(sentContent).toContain('&lt;script&gt;alert("x")&lt;/script&gt;');
+    });
+
     // verifies should handle different view names
     test('should handle different view names', () => {
       const viewNames = ['dashboard', 'login', 'profile', 'admin'];


### PR DESCRIPTION
## Summary
- sanitize error messages in view templates to prevent HTML injection
- test HTML escaping in error messages for renderView

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684bbef47bd08322875d8a8db5e34088