### PR TITLE
Improve inline comments in http and url utilities

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -172,41 +172,41 @@ function calculateContentLength(body) {
  */
 function buildCleanHeaders(headers, method, body) {
     // Normalize method to lower case or default to 'get' if invalid
-    let safeMethod = 'get'; // default for undefined or invalid method
+    let safeMethod = 'get'; // default for undefined or invalid method to avoid unexpected behavior
     if (typeof method === 'string' && method.trim()) {
-        safeMethod = method.toLowerCase();
+        safeMethod = method.toLowerCase(); // enforce consistent method casing for comparisons
     }
     console.log(`buildCleanHeaders is running with ${safeMethod}`); // Log normalized method for debugging header logic
     try {
         // Validate headers parameter - return original value for null/undefined
         if (headers === null) {
-            return null;
+            return null; // explicit null signals header stripping by caller
         }
         if (headers === undefined) {
-            return undefined;
+            return undefined; // propagate undefined to indicate missing param
         }
         if (!isValidObject(headers)) {
-            return {};
+            return {}; // fall back to empty object to prevent runtime errors
         }
         
         // Clone headers to avoid mutating original request object
         // Spreading creates shallow copy which is sufficient for header objects
-        const cleanHeaders = { ...headers };
+        const cleanHeaders = { ...headers }; // clone to avoid mutating caller's object
 
         // Remove all blacklisted headers that shouldn't be forwarded
         // Using forEach instead of filter to directly modify the object in-place
         // This is more memory efficient than creating a new object with filtered properties
-        HEADERS_TO_REMOVE.forEach(header => { 
-            delete cleanHeaders[header]; // Delete is safe here since we're working on a copy
+        HEADERS_TO_REMOVE.forEach(header => {
+            delete cleanHeaders[header]; // strip potentially dangerous headers
         });
 
         // Handle content-length based on method and body presence
         // GET or empty-body requests should never include content-length
         // Empty bodies include empty objects and zero-length buffers
-        const emptyObj = typeof body === 'object' && body !== null && !Buffer.isBuffer(body) && Object.keys(body).length === 0; // check for {}
-        const emptyBuf = Buffer.isBuffer(body) && body.length === 0; // check for Buffer.alloc(0)
-        if (emptyObj || emptyBuf) { delete cleanHeaders['content-length']; } // remove when payload is effectively empty
-        if (!body || safeMethod === 'get') { delete cleanHeaders['content-length']; } // remove for GET or missing body
+        const emptyObj = typeof body === 'object' && body !== null && !Buffer.isBuffer(body) && Object.keys(body).length === 0; // identify empty object to avoid false content length
+        const emptyBuf = Buffer.isBuffer(body) && body.length === 0; // empty buffer also means no body content
+        if (emptyObj || emptyBuf) { delete cleanHeaders['content-length']; } // remove header when payload is empty to avoid misleading size
+        if (!body || safeMethod === 'get') { delete cleanHeaders['content-length']; } // strip length for GET or when body absent
 
         // For non-GET requests with actual body content, set accurate content-length
         // Skip when body is empty object or zero-length buffer
@@ -214,25 +214,25 @@ function buildCleanHeaders(headers, method, body) {
         if (safeMethod !== 'get' && body && !emptyObj && !emptyBuf) {
             // Handle string bodies (most common case)
             if (typeof body === 'string' && body.length > 0) {
-                cleanHeaders['content-length'] = calculateContentLength(body);
+                cleanHeaders['content-length'] = calculateContentLength(body); // set byte-accurate length for string payloads
             }
             // Handle object bodies (JSON APIs) - check if object has properties
             else if (typeof body === 'object' && body !== null && !Buffer.isBuffer(body) && Object.keys(body).length > 0) {
-                cleanHeaders['content-length'] = calculateContentLength(body);
+                cleanHeaders['content-length'] = calculateContentLength(body); // calculate JSON body length for APIs
             }
             // Handle Buffer bodies with actual content
             else if (Buffer.isBuffer(body) && body.length > 0) {
-                cleanHeaders['content-length'] = calculateContentLength(body);
+                cleanHeaders['content-length'] = calculateContentLength(body); // compute length for binary payloads
             }
         }
 
-        console.log(`buildCleanHeaders is returning ${JSON.stringify(cleanHeaders)}`); // Log result for debugging
-        return cleanHeaders;
+        console.log(`buildCleanHeaders is returning ${JSON.stringify(cleanHeaders)}`); // trace sanitized header set
+        return cleanHeaders; // forward cleaned headers to caller
     } catch (error) {
         // Log error but return original headers as fallback
         // This prevents complete request failure due to header cleaning issues
-        qerrors(error, 'buildCleanHeaders', { method: safeMethod }); // log normalized method to aid debugging
-        return headers; // Fallback to original headers if cleaning fails
+        qerrors(error, 'buildCleanHeaders', { method: safeMethod }); // capture context for troubleshooting
+        return headers; // fallback keeps request usable even when cleaning fails
     }
 }
 
@@ -268,31 +268,31 @@ function buildCleanHeaders(headers, method, body) {
  * @returns {string|null} The header value or null if missing/error
  */
 function getRequiredHeader(req, res, headerName, statusCode, errorMessage) {
-  const normalizedName = typeof headerName === 'string' ? headerName.toLowerCase() : ''; // lower-case for reliable lookup
-  console.log(`getRequiredHeader is running with ${normalizedName}`); // Log normalized header extraction attempt
+  const normalizedName = typeof headerName === 'string' ? headerName.toLowerCase() : ''; // standardize name for consistent lookup
+  console.log(`getRequiredHeader is running with ${normalizedName}`); // log which header we expect for debugging
   try {
     // Safely access header value even if headers object is undefined
     // Express normalizes header names to lowercase, so this handles case variations
-    const headerValue = req?.headers?.[normalizedName];
+    const headerValue = req?.headers?.[normalizedName]; // optional chain avoids errors when headers undefined
 
     if (!headerValue) {
       // Send appropriate error response based on status code
       if (statusCode === 401) {
-        sendAuthError(res, errorMessage);
+        sendAuthError(res, errorMessage); // missing auth header triggers auth failure
       } else {
-        sendJsonResponse(res, statusCode, { error: errorMessage });
+        sendJsonResponse(res, statusCode, { error: errorMessage }); // generic error for other required headers
       }
-      console.log(`getRequiredHeader is returning null due to missing header`);
-      return null; // Signal to caller that header was missing
+      console.log(`getRequiredHeader is returning null due to missing header`); // trace failure path
+      return null; // signal to caller that header was missing
     }
 
-    console.log(`getRequiredHeader is returning ${headerValue}`); // Log successful extraction (be careful with sensitive headers in production)
-    return headerValue;
+    console.log(`getRequiredHeader is returning ${headerValue}`); // trace value for debugging (avoid logging secrets in production)
+    return headerValue; // provide caller with sanitized header value
   } catch (error) {
     // Handle unexpected errors in header processing
     qerrors(error, 'getRequiredHeader', { headerName: normalizedName, statusCode, errorMessage }); // log normalized name for consistency
-    sendServerError(res, 'Internal server error', error, 'getRequiredHeader');
-    return null; // Signal failure to calling code
+    sendServerError(res, 'Internal server error', error, 'getRequiredHeader'); // generic 500 with logging
+    return null; // signal failure to calling code
   }
 }
 

--- a/lib/url.js
+++ b/lib/url.js
@@ -66,36 +66,36 @@ function hasProtocol(url) {
  * @returns {string|null} The URL with protocol added or null if input is invalid
  */
 function ensureProtocol(url) {
-  console.log(`ensureProtocol is running with ${url}`); // Log input for debugging URL processing issues
+  console.log(`ensureProtocol is running with ${url}`); // trace incoming URL for debugging
   try {
     // Validate that input is a usable string before processing
     if (typeof url !== 'string' || !url) {
-      qerrors(new Error('invalid url input'), 'ensureProtocol', url); // Log invalid input with context
-      console.log(`ensureProtocol is returning null`); // Log early return for invalid input
-      return null; // Return null to signal invalid input to caller
+      qerrors(new Error('invalid url input'), 'ensureProtocol', url); // record misuse or programming error
+      console.log(`ensureProtocol is returning null`); // early exit for unusable input
+      return null; // propagate null to caller for invalid input
     }
 
-    const trimmedUrl = url.trim(); // Remove leading/trailing spaces to normalize input
+    const trimmedUrl = url.trim(); // discard whitespace to compare accurately
 
     // Handle empty or invalid input gracefully - return null for missing URLs
     if (trimmedUrl.length === 0) {
-      console.log(`ensureProtocol is returning null`); // Log fallback for empty input
-      return null; // Indicate invalid/missing URL input
+      console.log(`ensureProtocol is returning null`); // treat blank strings as invalid
+      return null; // indicate missing URL value
     }
 
-    let finalUrl = trimmedUrl; // Work with sanitized copy to avoid mutating input
+    let finalUrl = trimmedUrl; // sanitized copy prevents altering original value
 
     // Check if protocol is already present using centralized detection
-    if (!hasProtocol(finalUrl)) { 
-      finalUrl = 'https://' + finalUrl; 
+    if (!hasProtocol(finalUrl)) {
+      finalUrl = 'https://' + finalUrl; // default to https for security
     }
 
-    console.log(`ensureProtocol is returning ${finalUrl}`); // Log final URL for debugging
-    return finalUrl;
+    console.log(`ensureProtocol is returning ${finalUrl}`); // trace normalized URL
+    return finalUrl; // provide caller with safe URL
   } catch (error) {
     // Handle unexpected errors in URL processing
-    qerrors(error, 'ensureProtocol', url); // Log error with input context
-    return url; // Fallback: return original input if processing fails
+    qerrors(error, 'ensureProtocol', url); // log and keep original URL to avoid breaking caller
+    return url; // fallback to provided value if something went wrong
   }
 }
 
@@ -129,38 +129,38 @@ function ensureProtocol(url) {
  * @returns {string|null} The normalized origin in lowercase or null if invalid
  */
 function normalizeUrlOrigin(url) {
-  console.log(`normalizeUrlOrigin is running with ${url}`); // Log input for debugging normalization
+  console.log(`normalizeUrlOrigin is running with ${url}`); // track incoming URL before normalization
   try {
     // First ensure the URL has a protocol, then extract and normalize origin
-    const processedUrl = ensureProtocol(url);
+    const processedUrl = ensureProtocol(url); // add protocol if missing for valid parsing
 
     // If protocol normalization failed, abort parsing
     if (processedUrl === null) {
-      console.log(`normalizeUrlOrigin is returning null`); // Log early exit due to invalid input
-      return null;
+      console.log(`normalizeUrlOrigin is returning null`); // protocol check failed
+      return null; // cannot continue without valid protocol
     }
 
     // Parse the URL to extract components
     // This allows us to normalize the origin while preserving other parts
-    const urlObj = new URL(processedUrl);
+    const urlObj = new URL(processedUrl); // leverage built-in parser for reliability
 
     // Build normalized origin, preserving explicit ports (including 443 for HTTPS)
     // We use hostname instead of host to get just the domain without port
     // Then add port back explicitly if it exists to maintain consistency
-    let normalizedOrigin = `${urlObj.protocol}//${urlObj.hostname.toLowerCase()}`;
+    let normalizedOrigin = `${urlObj.protocol}//${urlObj.hostname.toLowerCase()}`; // start with protocol and lowercase host
     
     // Include port if explicitly specified (even standard ports like 443 for HTTPS)
     // This preserves the original intent when port was explicitly provided
     if (urlObj.port && urlObj.port !== '') {
-      normalizedOrigin += `:${urlObj.port}`;
+      normalizedOrigin += `:${urlObj.port}`; // retain explicit port to respect caller intent
     }
 
-    console.log(`normalizeUrlOrigin is returning ${normalizedOrigin}`); // Log successful normalization
-    return normalizedOrigin;
+    console.log(`normalizeUrlOrigin is returning ${normalizedOrigin}`); // output normalized origin for verification
+    return normalizedOrigin; // provide canonical origin
   } catch (error) {
     // Handle malformed URLs that can't be parsed
-    qerrors(error, 'normalizeUrlOrigin', url); // Log parsing error with context
-    return null; // Return null to indicate parsing failure
+    qerrors(error, 'normalizeUrlOrigin', url); // log parsing error for investigation
+    return null; // indicate failure so caller can react
   }
 }
 
@@ -195,19 +195,19 @@ function normalizeUrlOrigin(url) {
  * @returns {string} The URL without protocol prefix or trailing slash
  */
 function stripProtocol(url) {
-  console.log(`stripProtocol is running with ${url}`); // Log input for debugging strip operations
+  console.log(`stripProtocol is running with ${url}`); // trace original URL before modifications
   try {
     // Chain replacements to remove protocol and trailing slash
     // Using centralized regex pattern for consistency with other URL functions
     const processed = url
-      .replace(/^https?:\/\//i, '') // Remove protocol prefix (case-insensitive)
-      .replace(/\/$/, '');           // Remove trailing slash if present
-    console.log(`stripProtocol is returning ${processed}`); // Log processed result
-    return processed;
+      .replace(/^https?:\/\//i, '') // drop leading protocol so display is cleaner
+      .replace(/\/$/, '');           // trim trailing slash for uniformity
+    console.log(`stripProtocol is returning ${processed}`); // show stripped result
+    return processed; // send cleaned value back
   } catch (error) {
     // Handle unexpected errors in string processing
-    qerrors(error, 'stripProtocol', url); // Log error with context
-    return url; // Fallback: return original URL if processing fails
+    qerrors(error, 'stripProtocol', url); // log unexpected issue
+    return url; // fallback to input on failure
   }
 }
 
@@ -248,32 +248,32 @@ function stripProtocol(url) {
  * @returns {object|null} Object with baseUrl and endpoint properties, or null if parsing fails
  */
 function parseUrlParts(url) {
-  console.log(`parseUrlParts is running with ${url}`); // Log input for debugging URL parsing
+  console.log(`parseUrlParts is running with ${url}`); // trace incoming full URL
   try {
     // First normalize the URL to ensure it has a protocol for valid parsing
-    const processedUrl = ensureProtocol(url);
+    const processedUrl = ensureProtocol(url); // add protocol if absent to satisfy URL constructor
 
     // If protocol normalization failed, abort parsing
     if (processedUrl === null) {
-      console.log(`parseUrlParts is returning null`); // Log early exit due to invalid input
-      return null;
+      console.log(`parseUrlParts is returning null`); // normalization failed
+      return null; // cannot parse invalid URL
     }
 
     // Parse URL into components using native URL constructor
-    const parsed = new URL(processedUrl);
+    const parsed = new URL(processedUrl); // reliable parse of URL components
 
     // Create structured result with base URL and endpoint
     const result = {
-      baseUrl: parsed.origin,                    // Protocol + domain + port
-      endpoint: parsed.pathname + parsed.search  // Path + query parameters
+      baseUrl: parsed.origin,                    // protocol + domain + port only
+      endpoint: parsed.pathname + parsed.search  // path plus query string
     };
 
-    console.log(`parseUrlParts is returning ${JSON.stringify(result)}`); // Log structured result
-    return result;
+    console.log(`parseUrlParts is returning ${JSON.stringify(result)}`); // output parsed pieces
+    return result; // deliver structured parts
   } catch (error) {
     // Handle URLs that can't be parsed by URL constructor
-    qerrors(error, 'parseUrlParts', url); // Log parsing error with input context
-    return null; // Return null to indicate parsing failure
+    qerrors(error, 'parseUrlParts', url); // log failure for debugging
+    return null; // parsing failed
   }
 }
 


### PR DESCRIPTION
## Summary
- enhance inline comments in `buildCleanHeaders` and `getRequiredHeader`
- refine inline comments across URL helpers (`ensureProtocol`, `normalizeUrlOrigin`, `stripProtocol`, `parseUrlParts`)

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684ce80ab23483229cae494c28aba1ad