### PR TITLE
Add inline documentation for datetime and validation utilities

### DIFF
--- a/lib/datetime.js
+++ b/lib/datetime.js
@@ -27,7 +27,7 @@ const { logFunctionStart, logFunctionResult, logFunctionError } = require('./log
  * @returns {boolean} True if date is valid, false otherwise
  */
 function isValidDate(date) {
-  return !isNaN(date.getTime()) && date.toString() !== 'Invalid Date';
+  return !isNaN(date.getTime()) && date.toString() !== 'Invalid Date'; // treat NaN or Invalid Date as bad input
 }
 
 /**
@@ -65,27 +65,27 @@ function formatDateTime(dateString) {
   logFunctionStart('formatDateTime', dateString);
   try {
     // Handle empty or null input gracefully - common in optional date fields
-    if (!dateString) {
+    if (!dateString) { // short-circuit when input missing or blank
       logFunctionResult('formatDateTime', 'N/A');
-      return 'N/A'; // User-friendly indicator for missing dates
+      return 'N/A'; // return neutral value so UIs know no date was provided
     }
 
     // Convert ISO string to Date object and format according to user's locale
     // Date constructor can handle various ISO formats automatically
-    const date = new Date(dateString);
+    const date = new Date(dateString); // parse ISO string into Date for conversion
 
     // Handle invalid date strings using centralized validation
-    if (!isValidDate(date)) {
+    if (!isValidDate(date)) { // reject invalid dates to avoid misleading output
       logFunctionResult('formatDateTime', 'N/A');
       return 'N/A';
     }
-    const formatted = date.toLocaleString();
+    const formatted = date.toLocaleString(); // locale aware formatting for display
     logFunctionResult('formatDateTime', formatted);
-    return formatted;
+    return formatted; // send formatted date back to caller
   } catch (err) {
     // Handle invalid date strings that can't be parsed
     qerrors(err, 'formatDateTime', dateString); // Log parsing error with input context
-    return 'N/A'; // Fallback to indicate invalid date data
+    return 'N/A'; // final fallback keeps consumer code simple on failure
   }
 }
 
@@ -128,41 +128,41 @@ function formatDuration(startDateString, endDateString) {
   logFunctionStart('formatDuration', `${startDateString} and ${endDateString}`);
   try {
     // Handle edge cases gracefully
-    if (!startDateString || startDateString === '') {
+    if (!startDateString || startDateString === '') { // guard against missing start time
       logFunctionResult('formatDuration', '00:00:00');
       return '00:00:00';
     }
 
     // Validate start date using centralized validation
-    const startDate = new Date(startDateString);
+    const startDate = new Date(startDateString); // parse provided start time
     if (!isValidDate(startDate)) {
       throw new Error('Invalid start date');
     }
 
     // Calculate end time (current time if not provided)
-    const endTime = endDateString ? new Date(endDateString) : new Date();
+    const endTime = endDateString ? new Date(endDateString) : new Date(); // default to now if end omitted
 
     // Validate end date if provided using centralized validation
-    if (endDateString && !isValidDate(endTime)) {
+    if (endDateString && !isValidDate(endTime)) { // check provided end date only when set
       throw new Error('Invalid end date');
     }
 
     // Calculate duration in milliseconds and convert to absolute value
-    const durationMs = Math.abs(endTime - startDate);
+    const durationMs = Math.abs(endTime - startDate); // absolute diff handles reversed dates
 
     // Convert milliseconds to time components using standard time conversion
-    const hours = Math.floor(durationMs / (1000 * 60 * 60)); // 3600000 ms per hour
-    const minutes = Math.floor((durationMs % (1000 * 60 * 60)) / (1000 * 60)); // Remaining minutes
-    const seconds = Math.floor((durationMs % (1000 * 60)) / 1000); // Remaining seconds
+    const hours = Math.floor(durationMs / (1000 * 60 * 60)); // convert to hours
+    const minutes = Math.floor((durationMs % (1000 * 60 * 60)) / (1000 * 60)); // leftover minutes
+    const seconds = Math.floor((durationMs % (1000 * 60)) / 1000); // leftover seconds
 
     // Format with zero-padding for consistent display (padStart ensures 2 digits)
-    const formatted = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+    const formatted = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`; // pad for readability
     logFunctionResult('formatDuration', formatted);
-    return formatted;
+    return formatted; // return the duration string
   } catch (err) {
     // Handle invalid date strings or calculation errors and re-throw
     logFunctionError(err, 'formatDuration', { startDateString, endDateString });
-    throw err; // Re-throw to let caller handle date parsing errors appropriately
+    throw err; // let caller decide how to report invalid dates
   }
 }
 
@@ -187,4 +187,4 @@ function formatDuration(startDateString, endDateString) {
 module.exports = {
   formatDateTime, // export for date display
   formatDuration // export for duration display
-};
+}; // expose utilities for consumption

--- a/lib/input-validation.js
+++ b/lib/input-validation.js
@@ -32,7 +32,7 @@ const { qerrors } = require('qerrors'); // error logger used by validation helpe
  * @returns {boolean} True if valid object, false otherwise
  */
 function isValidObject(obj) {
-  return obj !== null && obj !== undefined && typeof obj === 'object' && !Array.isArray(obj);
+  return obj !== null && obj !== undefined && typeof obj === 'object' && !Array.isArray(obj); // reject null and arrays so only plain objects pass
 }
 
 /**
@@ -51,7 +51,7 @@ function isValidObject(obj) {
  * @returns {boolean} True if valid string, false otherwise
  */
 function isValidString(str) {
-  return typeof str === 'string' && str.trim().length > 0;
+  return typeof str === 'string' && str.trim().length > 0; // trim ensures no whitespace-only strings
 }
 
 /**
@@ -73,10 +73,10 @@ function isValidString(str) {
  */
 function hasMethod(obj, methodName) {
   try {
-    return !!(obj && typeof obj[methodName] === 'function'); // ensure boolean return for falsy objects
+    return !!(obj && typeof obj[methodName] === 'function'); // double negation guarantees true only when callable exists
   } catch (error) {
     qerrors(error, 'hasMethod', { obj: typeof obj, methodName });
-    return false;
+    return false; // fail closed so callers don't attempt to call missing method
   }
 }
 
@@ -97,7 +97,7 @@ function hasMethod(obj, methodName) {
  * @returns {boolean} True if valid Express response, false otherwise
  */
 function isValidExpressResponse(res) {
-  return hasMethod(res, 'status') && hasMethod(res, 'json');
+  return hasMethod(res, 'status') && hasMethod(res, 'json'); // both Express methods must be functions
 }
 
 module.exports = {
@@ -105,4 +105,4 @@ module.exports = {
   isValidString, // export string validator
   hasMethod, // export method checker
   isValidExpressResponse // export Express response checker
-};
+}; // export validators as a group


### PR DESCRIPTION
## Summary
- annotate datetime helper internals
- annotate input validation utility

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684ce80b4f4483229e9e84f75ebb3764