### PR TITLE
Add clarifying test comments

### DIFF
--- a/tests/integration/error-handling.test.js
+++ b/tests/integration/error-handling.test.js
@@ -17,23 +17,23 @@ describe('Error Handling Integration Tests', () => {
       
       // Test invalid URL processing
       const invalidUrl = null;
-      expect(utils.ensureProtocol(invalidUrl)).toBeNull();
-      expect(utils.normalizeUrlOrigin(invalidUrl)).toBeNull();
-      expect(utils.parseUrlParts(invalidUrl)).toBeNull();
+      expect(utils.ensureProtocol(invalidUrl)).toBeNull(); // invalid URL returns null
+      expect(utils.normalizeUrlOrigin(invalidUrl)).toBeNull(); // normalization also null
+      expect(utils.parseUrlParts(invalidUrl)).toBeNull(); // parsing fails gracefully
       
       // Test invalid date processing
       const invalidDate = 'not-a-date';
-      expect(utils.formatDateTime(invalidDate)).toBe('N/A');
+      expect(utils.formatDateTime(invalidDate)).toBe('N/A'); // invalid date yields N/A
       
       // Test invalid duration calculation should throw
-      expect(() => utils.formatDuration(invalidDate)).toThrow();
+      expect(() => utils.formatDuration(invalidDate)).toThrow(); // invalid duration throws
       
       // Test validation with malformed object
       expect(utils.requireFields(null, ['field'], mockRes)).toBe(false); // (reordered parameters to match obj, fields, res)
-      expect(mockRes.status).toHaveBeenCalledWith(500);
+        expect(mockRes.status).toHaveBeenCalledWith(500); // validation error results in server error
       
       // Test auth with malformed request
-      expect(utils.checkPassportAuth(null)).toBe(false);
+      expect(utils.checkPassportAuth(null)).toBe(false); // malformed req fails auth
     });
 
     // verifies should handle error propagation in API workflow
@@ -51,12 +51,12 @@ describe('Error Handling Integration Tests', () => {
       };
       
       // Each utility should handle the malformed data gracefully
-      expect(utils.checkPassportAuth(malformedReq)).toBe(false);
+      expect(utils.checkPassportAuth(malformedReq)).toBe(false); // auth fails with bad object
       
-      expect(utils.getRequiredHeader(malformedReq, mockRes, 'auth', 401, 'Missing')).toBeNull();
-      expect(mockRes.status).toHaveBeenCalledWith(401);
+      expect(utils.getRequiredHeader(malformedReq, mockRes, 'auth', 401, 'Missing')).toBeNull(); // header retrieval fails
+      expect(mockRes.status).toHaveBeenCalledWith(401); // unauthorized due to missing header
       
-      expect(utils.requireFields(malformedReq.body, ['field'], mockRes)).toBe(false); // (reordered parameters to match obj, fields, res)
+      expect(utils.requireFields(malformedReq.body, ['field'], mockRes)).toBe(false); // validation fails on body
     });
   });
 
@@ -79,13 +79,13 @@ describe('Error Handling Integration Tests', () => {
         expect(mockRes.status).toHaveBeenCalledWith(500);
         expect(mockRes.send).toHaveBeenCalledWith(
           expect.stringContaining(`${view} Error`)
-        );
+        ); // send error page for each view
       });
       
       // Should have attempted to render each view
-      expect(mockRes.render).toHaveBeenCalledTimes(3);
+      expect(mockRes.render).toHaveBeenCalledTimes(3); // attempted rendering each view
       // Should have sent error pages for each failure
-      expect(mockRes.send).toHaveBeenCalledTimes(3);
+      expect(mockRes.send).toHaveBeenCalledTimes(3); // error page sent each time
     });
 
     // verifies should handle route registration with missing global app
@@ -98,13 +98,13 @@ describe('Error Handling Integration Tests', () => {
         // Should not throw even with missing app
         expect(() => {
           utils.registerViewRoute('/test', 'test', 'Test Error');
-        }).not.toThrow();
+        }).not.toThrow(); // should not crash when app undefined
         
         global.app = null;
         
         expect(() => {
           utils.registerViewRoute('/test2', 'test2', 'Test Error 2');
-        }).not.toThrow();
+        }).not.toThrow(); // handle null app as well
         
       } finally {
         global.app = originalApp;
@@ -116,29 +116,29 @@ describe('Error Handling Integration Tests', () => {
     // verifies should handle content-length calculation errors
     test('should handle content-length calculation errors', () => {
       // These should handle gracefully without throwing
-      expect(utils.calculateContentLength(null)).toBe('0');
-      expect(utils.calculateContentLength('')).toBe('0');
-      expect(utils.calculateContentLength({})).toBe('0');
+      expect(utils.calculateContentLength(null)).toBe('0'); // null yields zero
+      expect(utils.calculateContentLength('')).toBe('0'); // empty string yields zero
+      expect(utils.calculateContentLength({})).toBe('0'); // empty object yields zero
       
       // This should throw as expected
-      expect(() => utils.calculateContentLength(undefined)).toThrow('Body is undefined');
+      expect(() => utils.calculateContentLength(undefined)).toThrow('Body is undefined'); // undefined still throws
       
       // Complex object should work
       const complexObj = { nested: { data: [1, 2, 3] } };
       const result = utils.calculateContentLength(complexObj);
-      expect(typeof result).toBe('string');
-      expect(parseInt(result)).toBeGreaterThan(0);
+      expect(typeof result).toBe('string'); // returned as string
+      expect(parseInt(result)).toBeGreaterThan(0); // length positive
     });
 
     // verifies should handle header cleaning with malformed headers
     test('should handle header cleaning with malformed headers', () => {
       // Should handle null/undefined headers
-      expect(utils.buildCleanHeaders(null, 'GET', null)).toEqual(null);
-      expect(utils.buildCleanHeaders(undefined, 'GET', null)).toEqual(undefined);
+      expect(utils.buildCleanHeaders(null, 'GET', null)).toEqual(null); // null headers return null
+      expect(utils.buildCleanHeaders(undefined, 'GET', null)).toEqual(undefined); // undefined returns undefined
       
       // Should handle empty headers
       const result = utils.buildCleanHeaders({}, 'POST', { data: 'test' });
-      expect(result).toEqual({ 'content-length': utils.calculateContentLength({ data: 'test' }) });
+      expect(result).toEqual({ 'content-length': utils.calculateContentLength({ data: 'test' }) }); // only length header added
     });
   });
 
@@ -204,8 +204,8 @@ describe('Error Handling Integration Tests', () => {
         // ensureProtocol should return null for invalid inputs
         const withProtocol = utils.ensureProtocol(url);
         if (withProtocol === null) {
-          expect(utils.normalizeUrlOrigin(url)).toBeNull();
-          expect(utils.parseUrlParts(url)).toBeNull();
+          expect(utils.normalizeUrlOrigin(url)).toBeNull(); // invalid URL remains null
+          expect(utils.parseUrlParts(url)).toBeNull(); // parsing returns null
         }
       });
     });
@@ -222,21 +222,21 @@ describe('Error Handling Integration Tests', () => {
       
       edgeCaseUrls.forEach(url => {
         const withProtocol = utils.ensureProtocol(url);
-        expect(withProtocol).toContain('https://');
+        expect(withProtocol).toContain('https://'); // protocol enforced
 
         const normalized = utils.normalizeUrlOrigin(url);
         if (normalized) {
-          expect(normalized).toContain('https://');
+          expect(normalized).toContain('https://'); // normalization adds protocol
         } else {
-          expect(normalized).toBeNull();
+          expect(normalized).toBeNull(); // invalid normalization results null
         }
 
         const parsed = utils.parseUrlParts(url);
         if (parsed) {
-          expect(parsed).toHaveProperty('baseUrl');
-          expect(parsed).toHaveProperty('endpoint');
+          expect(parsed).toHaveProperty('baseUrl'); // object must contain baseUrl
+          expect(parsed).toHaveProperty('endpoint'); // object must contain endpoint
         } else {
-          expect(parsed).toBeNull();
+          expect(parsed).toBeNull(); // invalid parsing results null
         }
       });
     });
@@ -263,8 +263,8 @@ describe('Error Handling Integration Tests', () => {
         mockRes.json.mockClear();
         
         const result = utils.requireFields(obj, fields, mockRes); // (reordered parameters to match obj, fields, res)
-        expect(result).toBe(false);
-        expect(mockRes.status).toHaveBeenCalledWith(expectedStatus);
+        expect(result).toBe(false); // validation fails as expected
+        expect(mockRes.status).toHaveBeenCalledWith(expectedStatus); // status matches table
       });
     });
   });

--- a/tests/integration/module-interactions.test.js
+++ b/tests/integration/module-interactions.test.js
@@ -23,11 +23,11 @@ describe('Module Integration Tests', () => {
       
       // Process URL
       const processedUrl = ensureProtocol(url);
-      expect(processedUrl).toBe('https://api.example.com/users');
+      expect(processedUrl).toBe('https://api.example.com/users'); // ensure protocol added
       
       // Calculate content length for request body
       const contentLength = calculateContentLength(body);
-      expect(contentLength).toBe(Buffer.byteLength(JSON.stringify(body), 'utf8').toString());
+      expect(contentLength).toBe(Buffer.byteLength(JSON.stringify(body), 'utf8').toString()); // compare calculated length
       
       // Build clean headers
       const headers = buildCleanHeaders({
@@ -35,8 +35,8 @@ describe('Module Integration Tests', () => {
         'host': 'evil.com'
       }, 'POST', body);
       
-      expect(headers['content-length']).toBe(contentLength);
-      expect(headers['host']).toBeUndefined();
+      expect(headers['content-length']).toBe(contentLength); // header set correctly
+      expect(headers['host']).toBeUndefined(); // host stripped
     });
 
     // verifies should normalize URLs and build appropriate headers
@@ -50,9 +50,9 @@ describe('Module Integration Tests', () => {
       const normalizedOrigins = urls.map(normalizeUrlOrigin);
       
       // All should normalize to the same origin
-      expect(normalizedOrigins[0]).toBe('https://api.example.com');
-      expect(normalizedOrigins[1]).toBe('https://api.example.com');
-      expect(normalizedOrigins[2]).toBe('http://api.example.com');
+      expect(normalizedOrigins[0]).toBe('https://api.example.com'); // https url normalized
+      expect(normalizedOrigins[1]).toBe('https://api.example.com'); // missing protocol normalized
+      expect(normalizedOrigins[2]).toBe('http://api.example.com'); // http kept
       
       // Headers should be clean for any method
       const headers = buildCleanHeaders({
@@ -60,8 +60,8 @@ describe('Module Integration Tests', () => {
         'x-target-url': normalizedOrigins[0]
       }, 'GET', null);
       
-      expect(headers['authorization']).toBe('Bearer token');
-      expect(headers['x-target-url']).toBeUndefined();
+      expect(headers['authorization']).toBe('Bearer token'); // auth header kept
+      expect(headers['x-target-url']).toBeUndefined(); // target url stripped
     });
   });
 
@@ -82,12 +82,12 @@ describe('Module Integration Tests', () => {
       
       // Check authentication first
       const isAuth = checkPassportAuth(mockAuthReq);
-      expect(isAuth).toBe(true);
+      expect(isAuth).toBe(true); // authentication succeeded
       
       // Then validate required fields
       const isValid = requireFields(mockAuthReq.body, ['title', 'content'], mockRes); // (reordered parameters to match obj, fields, res)
-      expect(isValid).toBe(true);
-      expect(mockRes.status).not.toHaveBeenCalled();
+      expect(isValid).toBe(true); // fields valid
+      expect(mockRes.status).not.toHaveBeenCalled(); // no error status
     });
 
     // verifies should handle unauthenticated user with valid fields
@@ -104,11 +104,11 @@ describe('Module Integration Tests', () => {
       
       // Authentication fails
       const isAuth = checkPassportAuth(mockUnauthReq);
-      expect(isAuth).toBe(false);
+      expect(isAuth).toBe(false); // authentication fails
       
       // Fields are valid but auth failed
       const isValid = requireFields(mockUnauthReq.body, ['title', 'content'], mockRes); // (reordered parameters to match obj, fields, res)
-      expect(isValid).toBe(true);
+      expect(isValid).toBe(true); // fields still valid
     });
   });
 
@@ -140,10 +140,10 @@ describe('Module Integration Tests', () => {
       // Send response
       utils.sendJsonResponse(mockRes, 200, responseData);
       
-      expect(mockRes.status).toHaveBeenCalledWith(200);
-      expect(mockRes.json).toHaveBeenCalledWith(responseData);
-      expect(formattedStart).not.toBe('N/A');
-      expect(duration).toBe('01:30:45');
+      expect(mockRes.status).toHaveBeenCalledWith(200); // success status returned
+      expect(mockRes.json).toHaveBeenCalledWith(responseData); // response payload returned
+      expect(formattedStart).not.toBe('N/A'); // date formatted
+      expect(duration).toBe('01:30:45'); // duration calculation
     });
 
     // verifies should handle malformed dates in HTTP context
@@ -211,9 +211,9 @@ describe('Module Integration Tests', () => {
       
       // Step 5: Build clean headers for proxying
       const cleanHeaders = buildCleanHeaders(mockReq.headers, 'POST', mockReq.body);
-      expect(cleanHeaders['authorization']).toBe('Bearer valid-token');
-      expect(cleanHeaders['host']).toBeUndefined();
-      expect(cleanHeaders['x-target-url']).toBeUndefined();
+      expect(cleanHeaders['authorization']).toBe('Bearer valid-token'); // auth header kept
+      expect(cleanHeaders['host']).toBeUndefined(); // host removed for proxying
+      expect(cleanHeaders['x-target-url']).toBeUndefined(); // internal header removed
       
       // Step 6: Format timestamps in response
       const formattedDate = formatDateTime(mockReq.body.published_at);
@@ -228,8 +228,8 @@ describe('Module Integration Tests', () => {
       
       utils.sendJsonResponse(mockRes, 201, responseData);
       
-      expect(mockRes.status).toHaveBeenCalledWith(201);
-      expect(mockRes.json).toHaveBeenCalledWith(responseData);
+      expect(mockRes.status).toHaveBeenCalledWith(201); // return created status
+      expect(mockRes.json).toHaveBeenCalledWith(responseData); // send data
     });
 
     // verifies should handle complete workflow with validation failure
@@ -247,13 +247,13 @@ describe('Module Integration Tests', () => {
       };
       
       // Authentication passes
-      expect(checkPassportAuth(mockReq)).toBe(true);
+      expect(checkPassportAuth(mockReq)).toBe(true); // auth check passes
       
       // Validation fails
       const fieldsValid = requireFields(mockReq.body, ['title', 'content'], mockRes); // (reordered parameters to match obj, fields, res)
-      expect(fieldsValid).toBe(false);
-      expect(mockRes.status).toHaveBeenCalledWith(400);
-      expect(mockRes.json).toHaveBeenCalledWith({
+      expect(fieldsValid).toBe(false); // validation fails
+      expect(mockRes.status).toHaveBeenCalledWith(400); // 400 returned
+      expect(mockRes.json).toHaveBeenCalledWith({ // error payload returned
         error: 'Missing required fields',
         missing: ['content']
       });
@@ -273,11 +273,11 @@ describe('Module Integration Tests', () => {
       };
       
       // Authentication fails early
-      expect(checkPassportAuth(mockReq)).toBe(false);
+      expect(checkPassportAuth(mockReq)).toBe(false); // authentication failure
       
       // Even though fields are valid, auth failed
       const fieldsValid = requireFields(mockReq.body, ['title', 'content'], mockRes); // (reordered parameters to match obj, fields, res)
-      expect(fieldsValid).toBe(true);
+      expect(fieldsValid).toBe(true); // fields still valid despite auth failure
       
       // In a real app, we'd return 401 for auth failure before validating fields
     });

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -47,12 +47,12 @@ console.log(`Root Directory: ${testConfig.rootDir}`);
 console.log(`Jest Arguments: ${jestArgs.join(' ')}\n`);
 
 // Run Jest
-const jest = spawn('npx', ['jest', ...jestArgs], {
+const jest = spawn('npx', ['jest', ...jestArgs], { // spawn Jest child process
   stdio: 'inherit',
   cwd: testConfig.rootDir
 });
 
-jest.on('close', (code) => {
+jest.on('close', (code) => { // handle jest exit
   if (code === 0) {
     console.log('\n✅ All tests passed!');
   } else {
@@ -61,19 +61,19 @@ jest.on('close', (code) => {
   }
 });
 
-jest.on('error', (error) => {
+jest.on('error', (error) => { // spawn error handling
   console.error('❌ Failed to start test runner:', error);
   process.exit(1);
 });
 
 // Handle process termination
-process.on('SIGINT', () => {
+process.on('SIGINT', () => { // allow Ctrl+C to stop tests
   console.log('\n⚠️  Test runner interrupted');
   jest.kill('SIGINT');
   process.exit(130);
 });
 
-process.on('SIGTERM', () => {
+process.on('SIGTERM', () => { // handle termination signal
   console.log('\n⚠️  Test runner terminated');
   jest.kill('SIGTERM');
   process.exit(143);

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -12,7 +12,7 @@ global.console = {
 };
 
 // Mock qerrors to prevent actual error logging during tests
-jest.mock('qerrors', () => ({
+jest.mock('qerrors', () => ({ // stub qerrors during tests
   qerrors: jest.fn((error, context, data) => {
     // Log the mock call for debugging if needed
     // console.error(`Mock qerrors called: ${error.message || error}`);
@@ -20,10 +20,10 @@ jest.mock('qerrors', () => ({
 }));
 
 // Set up global test environment
-global.mockConsole = global.console;
+global.mockConsole = global.console; // expose mocked console for assertions
 
 // Global test helpers
-global.createMockRequest = (overrides = {}) => ({
+global.createMockRequest = (overrides = {}) => ({ // helper builds fake req
   headers: {},
   body: {},
   query: {},
@@ -33,7 +33,7 @@ global.createMockRequest = (overrides = {}) => ({
   ...overrides
 });
 
-global.createMockResponse = (overrides = {}) => ({
+global.createMockResponse = (overrides = {}) => ({ // helper builds fake res
   status: jest.fn().mockReturnThis(),
   json: jest.fn().mockReturnThis(),
   send: jest.fn().mockReturnThis(),
@@ -43,11 +43,11 @@ global.createMockResponse = (overrides = {}) => ({
 });
 
 // Set up global test timeout
-jest.setTimeout(10000);
+jest.setTimeout(10000); // allow async tests up to 10s
 
 // Clean up after each test
 afterEach(() => {
-  jest.clearAllMocks();
+  jest.clearAllMocks(); // reset spies between tests
 });
 
 // Set up test environment

--- a/tests/unit/additional-edge-cases.test.js
+++ b/tests/unit/additional-edge-cases.test.js
@@ -11,14 +11,14 @@ const { qerrors } = require('qerrors');
 describe('Additional Edge Cases', () => {
   describe('calculateContentLength', () => {
     test('should return 0 for boolean body', () => {
-      expect(httpUtils.calculateContentLength(true)).toBe('0');
+      expect(httpUtils.calculateContentLength(true)).toBe('0'); // boolean coerces to empty payload length
     });
   });
 
   describe('buildCleanHeaders', () => {
     test('should return empty object when headers not object', () => {
       const result = httpUtils.buildCleanHeaders('bad', 'GET', null);
-      expect(result).toEqual({});
+      expect(result).toEqual({}); // invalid headers should yield empty object
     });
 
     test('should return original headers on error', () => {
@@ -26,24 +26,24 @@ describe('Additional Edge Cases', () => {
       circular.self = circular; // create JSON.stringify failure case
       const headers = { 'content-type': 'application/json' };
       const result = httpUtils.buildCleanHeaders(headers, 'POST', circular);
-      expect(qerrors).toHaveBeenCalled();
-      expect(result).toBe(headers);
+      expect(qerrors).toHaveBeenCalled(); // ensure error logged for circular reference
+      expect(result).toBe(headers); // original headers returned when error occurs
     });
   });
 
   describe('stripProtocol', () => {
     test('should return input when not string and log error', () => {
       const result = urlUtils.stripProtocol(null);
-      expect(qerrors).toHaveBeenCalled();
-      expect(result).toBeNull();
+      expect(qerrors).toHaveBeenCalled(); // confirm error logged for bad input
+      expect(result).toBeNull(); // invalid input returns null
     });
   });
 
   describe('parseUrlParts', () => {
     test('should return null for malformed url with protocol only', () => {
       const result = urlUtils.parseUrlParts('http://');
-      expect(qerrors).toHaveBeenCalled();
-      expect(result).toBeNull();
+      expect(qerrors).toHaveBeenCalled(); // invalid url should trigger logging
+      expect(result).toBeNull(); // result should be null on failure
     });
   });
 });

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -12,8 +12,8 @@ describe('Authentication Utilities', () => {
         isAuthenticated: jest.fn().mockReturnValue(true)
       };
       
-      expect(checkPassportAuth(mockReq)).toBe(true);
-      expect(mockReq.isAuthenticated).toHaveBeenCalled();
+      expect(checkPassportAuth(mockReq)).toBe(true); // should succeed for logged-in user
+      expect(mockReq.isAuthenticated).toHaveBeenCalled(); // verify auth check invoked
     });
 
     // verifies should return false for unauthenticated user
@@ -22,8 +22,8 @@ describe('Authentication Utilities', () => {
         isAuthenticated: jest.fn().mockReturnValue(false)
       };
       
-      expect(checkPassportAuth(mockReq)).toBe(false);
-      expect(mockReq.isAuthenticated).toHaveBeenCalled();
+      expect(checkPassportAuth(mockReq)).toBe(false); // expected failure for guest
+      expect(mockReq.isAuthenticated).toHaveBeenCalled(); // ensure method called
     });
 
     // verifies should return false when isAuthenticated method is missing
@@ -32,12 +32,12 @@ describe('Authentication Utilities', () => {
         user: { username: 'john_doe' }
       };
       
-      expect(checkPassportAuth(mockReq)).toBe(false);
+      expect(checkPassportAuth(mockReq)).toBe(false); // missing method means unauthenticated
     });
 
     // verifies should return false for empty request object
     test('should return false for empty request object', () => {
-      expect(checkPassportAuth({})).toBe(false);
+      expect(checkPassportAuth({})).toBe(false); // empty object should fail auth
     });
 
     // verifies should return false when isAuthenticated throws error
@@ -48,13 +48,13 @@ describe('Authentication Utilities', () => {
         })
       };
       
-      expect(checkPassportAuth(mockReq)).toBe(false);
+      expect(checkPassportAuth(mockReq)).toBe(false); // error thrown should result in false
     });
 
     // verifies should handle malformed request object
     test('should handle malformed request object', () => {
-      expect(checkPassportAuth(null)).toBe(false);
-      expect(checkPassportAuth(undefined)).toBe(false);
+      expect(checkPassportAuth(null)).toBe(false); // null request fails auth
+      expect(checkPassportAuth(undefined)).toBe(false); // undefined request fails auth
     });
 
     // verifies should handle truthy but non-boolean return from isAuthenticated
@@ -63,7 +63,7 @@ describe('Authentication Utilities', () => {
         isAuthenticated: jest.fn().mockReturnValue('truthy-string')
       };
       
-      expect(checkPassportAuth(mockReq)).toBe(true);
+      expect(checkPassportAuth(mockReq)).toBe(true); // non-boolean truthy counts as authenticated
     });
 
     // verifies should handle falsy but non-boolean return from isAuthenticated
@@ -72,7 +72,7 @@ describe('Authentication Utilities', () => {
         isAuthenticated: jest.fn().mockReturnValue(0)
       };
       
-      expect(checkPassportAuth(mockReq)).toBe(false);
+      expect(checkPassportAuth(mockReq)).toBe(false); // non-boolean falsy treated as unauthenticated
     });
   });
 
@@ -95,7 +95,7 @@ describe('Authentication Utilities', () => {
         }
       };
       
-      expect(hasGithubStrategy()).toBe(true);
+      expect(hasGithubStrategy()).toBe(true); // function should detect github strategy
     });
 
     // verifies should return false when GitHub strategy is not configured
@@ -106,7 +106,7 @@ describe('Authentication Utilities', () => {
         }
       };
       
-      expect(hasGithubStrategy()).toBe(false);
+      expect(hasGithubStrategy()).toBe(false); // should fail when only local strategy exists
     });
 
     // verifies should return false when no strategies are configured
@@ -115,25 +115,25 @@ describe('Authentication Utilities', () => {
         _strategies: {}
       };
       
-      expect(hasGithubStrategy()).toBe(false);
+      expect(hasGithubStrategy()).toBe(false); // no strategies returns false
     });
 
     // verifies should return false when passport is undefined
     test('should return false when passport is undefined', () => {
       global.passport = undefined;
-      expect(hasGithubStrategy()).toBe(false);
+      expect(hasGithubStrategy()).toBe(false); // undefined passport should be handled
     });
 
     // verifies should return false when passport is null
     test('should return false when passport is null', () => {
       global.passport = null;
-      expect(hasGithubStrategy()).toBe(false);
+      expect(hasGithubStrategy()).toBe(false); // null passport should be handled
     });
 
     // verifies should return false when _strategies is missing
     test('should return false when _strategies is missing', () => {
       global.passport = {};
-      expect(hasGithubStrategy()).toBe(false);
+      expect(hasGithubStrategy()).toBe(false); // missing strategies property returns false
     });
 
     // verifies should return false when _strategies is null
@@ -142,7 +142,7 @@ describe('Authentication Utilities', () => {
         _strategies: null
       };
       
-      expect(hasGithubStrategy()).toBe(false);
+      expect(hasGithubStrategy()).toBe(false); // null strategies property handled
     });
 
     // verifies should handle errors in strategy detection
@@ -153,7 +153,7 @@ describe('Authentication Utilities', () => {
         }
       };
 
-      expect(hasGithubStrategy()).toBe(false);
+      expect(hasGithubStrategy()).toBe(false); // catching error should result in false
     });
 
     // verifies should ignore local passport variable when global.passport is undefined
@@ -161,14 +161,14 @@ describe('Authentication Utilities', () => {
       const passport = { _strategies: { github: {} } }; // local variable with strategy
       global.passport = undefined; // global remains undefined
 
-      expect(hasGithubStrategy()).toBe(false);
+      expect(hasGithubStrategy()).toBe(false); // global undefined should override local variable
     });
 
     // verifies should return false when _strategies is not an object
     test('should return false when _strategies is not an object', () => {
       global.passport = { _strategies: 'invalid' };
 
-      expect(hasGithubStrategy()).toBe(false);
+      expect(hasGithubStrategy()).toBe(false); // non-object strategies results in false
     });
   });
 });

--- a/tests/unit/datetime.test.js
+++ b/tests/unit/datetime.test.js
@@ -14,22 +14,22 @@ describe('DateTime Utilities', () => {
 
     // verifies should return "N/A" for empty string
     test('should return "N/A" for empty string', () => {
-      expect(formatDateTime('')).toBe('N/A');
+      expect(formatDateTime('')).toBe('N/A'); // empty string yields fallback value
     });
 
     // verifies should return "N/A" for null input
     test('should return "N/A" for null input', () => {
-      expect(formatDateTime(null)).toBe('N/A');
+      expect(formatDateTime(null)).toBe('N/A'); // null should produce N/A
     });
 
     // verifies should return "N/A" for undefined input
     test('should return "N/A" for undefined input', () => {
-      expect(formatDateTime(undefined)).toBe('N/A');
+      expect(formatDateTime(undefined)).toBe('N/A'); // undefined should produce N/A
     });
 
     // verifies should return "N/A" for invalid date string
     test('should return "N/A" for invalid date string', () => {
-      expect(formatDateTime('invalid-date')).toBe('N/A');
+      expect(formatDateTime('invalid-date')).toBe('N/A'); // invalid date string triggers fallback
     });
 
     // verifies should handle different ISO formats
@@ -42,8 +42,8 @@ describe('DateTime Utilities', () => {
       
       formats.forEach(format => {
         const result = formatDateTime(format);
-        expect(result).not.toBe('N/A');
-        expect(typeof result).toBe('string');
+        expect(result).not.toBe('N/A'); // each format should produce valid string
+        expect(typeof result).toBe('string'); // confirm return type
       });
     });
   });
@@ -53,55 +53,55 @@ describe('DateTime Utilities', () => {
     test('should calculate duration between two valid dates', () => {
       const start = '2023-12-25T10:00:00.000Z';
       const end = '2023-12-25T11:30:45.000Z';
-      expect(formatDuration(start, end)).toBe('01:30:45');
+      expect(formatDuration(start, end)).toBe('01:30:45'); // computed difference should match
     });
 
     // verifies should calculate duration from start to now when end is not provided
     test('should calculate duration from start to now when end is not provided', () => {
       const start = new Date(Date.now() - 3661000).toISOString(); // 1 hour, 1 minute, 1 second ago
       const result = formatDuration(start);
-      expect(result).toMatch(/\d{2}:\d{2}:\d{2}/);
+      expect(result).toMatch(/\d{2}:\d{2}:\d{2}/); // should return h:m:s pattern
     });
 
     // verifies should return "00:00:00" for empty start date
     test('should return "00:00:00" for empty start date', () => {
-      expect(formatDuration('')).toBe('00:00:00');
+      expect(formatDuration('')).toBe('00:00:00'); // empty input yields zeros
     });
 
     // verifies should return "00:00:00" for null start date
     test('should return "00:00:00" for null start date', () => {
-      expect(formatDuration(null)).toBe('00:00:00');
+      expect(formatDuration(null)).toBe('00:00:00'); // null start treated as 0 duration
     });
 
     // verifies should handle same start and end dates
     test('should handle same start and end dates', () => {
       const date = '2023-12-25T10:00:00.000Z';
-      expect(formatDuration(date, date)).toBe('00:00:00');
+      expect(formatDuration(date, date)).toBe('00:00:00'); // same start and end produce zero duration
     });
 
     // verifies should handle end date before start date (absolute difference)
     test('should handle end date before start date (absolute difference)', () => {
       const start = '2023-12-25T11:00:00.000Z';
       const end = '2023-12-25T10:00:00.000Z';
-      expect(formatDuration(start, end)).toBe('01:00:00');
+      expect(formatDuration(start, end)).toBe('01:00:00'); // negative duration handled as absolute
     });
 
     // verifies should throw error for invalid start date
     test('should throw error for invalid start date', () => {
-      expect(() => formatDuration('invalid-date')).toThrow();
+      expect(() => formatDuration('invalid-date')).toThrow(); // invalid start date should throw
     });
 
     // verifies should throw error for invalid end date
     test('should throw error for invalid end date', () => {
       const start = '2023-12-25T10:00:00.000Z';
-      expect(() => formatDuration(start, 'invalid-date')).toThrow();
+      expect(() => formatDuration(start, 'invalid-date')).toThrow(); // invalid end date should throw
     });
 
     // verifies should format durations correctly with zero padding
     test('should format durations correctly with zero padding', () => {
       const start = '2023-12-25T10:00:00.000Z';
       const end = '2023-12-25T10:05:03.000Z';
-      expect(formatDuration(start, end)).toBe('00:05:03');
+      expect(formatDuration(start, end)).toBe('00:05:03'); // verify zero padding for each unit
     });
   });
 });

--- a/tests/unit/http.test.js
+++ b/tests/unit/http.test.js
@@ -9,41 +9,41 @@ describe('HTTP Utilities', () => {
   describe('calculateContentLength', () => {
     // verifies should calculate length for string body
     test('should calculate length for string body', () => {
-      expect(calculateContentLength('Hello World')).toBe('11');
+      expect(calculateContentLength('Hello World')).toBe('11'); // bytes count for string body
     });
 
     // verifies should calculate length for object body
     test('should calculate length for object body', () => {
       const obj = { name: 'John', age: 30 };
       const expected = Buffer.byteLength(JSON.stringify(obj), 'utf8').toString();
-      expect(calculateContentLength(obj)).toBe(expected);
+      expect(calculateContentLength(obj)).toBe(expected); // verifies object size calculation
     });
 
     // verifies should return "0" for empty string
     test('should return "0" for empty string', () => {
-      expect(calculateContentLength('')).toBe('0');
+      expect(calculateContentLength('')).toBe('0'); // no content should return zero
     });
 
     // verifies should return "0" for empty object
     test('should return "0" for empty object', () => {
-      expect(calculateContentLength({})).toBe('0');
+      expect(calculateContentLength({})).toBe('0'); // empty object yields zero bytes
     });
 
     // verifies should return "0" for null body
     test('should return "0" for null body', () => {
-      expect(calculateContentLength(null)).toBe('0');
+      expect(calculateContentLength(null)).toBe('0'); // null body produces zero
     });
 
     // verifies should throw error for undefined body
     test('should throw error for undefined body', () => {
-      expect(() => calculateContentLength(undefined)).toThrow('Body is undefined');
+      expect(() => calculateContentLength(undefined)).toThrow('Body is undefined'); // undefined body should throw
     });
 
     // verifies should handle UTF-8 characters correctly
     test('should handle UTF-8 characters correctly', () => {
       const utf8String = 'café';
       const expected = Buffer.byteLength(utf8String, 'utf8').toString();
-      expect(calculateContentLength(utf8String)).toBe(expected);
+      expect(calculateContentLength(utf8String)).toBe(expected); // verify multibyte chars counted correctly
     });
 
     // verifies should handle complex nested objects
@@ -53,13 +53,13 @@ describe('HTTP Utilities', () => {
         data: [1, 2, 3]
       };
       const expected = Buffer.byteLength(JSON.stringify(complexObj), 'utf8').toString();
-      expect(calculateContentLength(complexObj)).toBe(expected);
+      expect(calculateContentLength(complexObj)).toBe(expected); // nested object should serialize consistently
     });
 
     // verifies should calculate length for Buffer body
     test('should calculate length for Buffer body', () => {
       const buf = Buffer.from('abc');
-      expect(calculateContentLength(buf)).toBe(buf.length.toString());
+      expect(calculateContentLength(buf)).toBe(buf.length.toString()); // buffer length returned as string
     });
   });
 
@@ -77,14 +77,14 @@ describe('HTTP Utilities', () => {
     test('should remove dangerous headers for GET request', () => {
       const result = buildCleanHeaders(originalHeaders, 'GET', null);
       
-      expect(result['authorization']).toBe('Bearer token123');
-      expect(result['content-type']).toBe('application/json');
-      expect(result['user-agent']).toBe('MyApp/1.0');
+      expect(result['authorization']).toBe('Bearer token123'); // auth header preserved
+      expect(result['content-type']).toBe('application/json'); // content-type kept
+      expect(result['user-agent']).toBe('MyApp/1.0'); // user-agent kept
       
-      expect(result['host']).toBeUndefined();
-      expect(result['x-target-url']).toBeUndefined();
-      expect(result['cf-ray']).toBeUndefined();
-      expect(result['content-length']).toBeUndefined();
+      expect(result['host']).toBeUndefined(); // host removed for security
+      expect(result['x-target-url']).toBeUndefined(); // upstream url stripped
+      expect(result['cf-ray']).toBeUndefined(); // cf specific header removed
+      expect(result['content-length']).toBeUndefined(); // not added for GET
     });
 
     // verifies should remove dangerous headers and set content-length for POST with body
@@ -92,53 +92,53 @@ describe('HTTP Utilities', () => {
       const body = { name: 'test' };
       const result = buildCleanHeaders(originalHeaders, 'POST', body);
       
-      expect(result['authorization']).toBe('Bearer token123');
-      expect(result['content-type']).toBe('application/json');
-      expect(result['content-length']).toBe(calculateContentLength(body));
+      expect(result['authorization']).toBe('Bearer token123'); // auth header preserved for POST
+      expect(result['content-type']).toBe('application/json'); // content-type kept
+      expect(result['content-length']).toBe(calculateContentLength(body)); // length header set from body
       
-      expect(result['host']).toBeUndefined();
-      expect(result['x-target-url']).toBeUndefined();
-      expect(result['cf-ray']).toBeUndefined();
+      expect(result['host']).toBeUndefined(); // host stripped
+      expect(result['x-target-url']).toBeUndefined(); // remove forwarding header
+      expect(result['cf-ray']).toBeUndefined(); // remove cf data
     });
 
     // verifies should not set content-length for POST without body
     test('should not set content-length for POST without body', () => {
       const result = buildCleanHeaders(originalHeaders, 'POST', null);
-      expect(result['content-length']).toBeUndefined();
+      expect(result['content-length']).toBeUndefined(); // no body means no length header
     });
 
     // verifies should remove content-length when body is empty object
     test('should remove content-length when body is empty object', () => {
       const input = { 'content-length': '10' };
       const result = buildCleanHeaders(input, 'POST', {});
-      expect(result['content-length']).toBeUndefined();
+      expect(result['content-length']).toBeUndefined(); // empty object should remove length
     });
 
     // verifies should remove content-length when body is empty buffer
     test('should remove content-length when body is empty buffer', () => {
       const input = { 'content-length': '5' };
       const result = buildCleanHeaders(input, 'POST', Buffer.alloc(0));
-      expect(result['content-length']).toBeUndefined();
+      expect(result['content-length']).toBeUndefined(); // empty buffer should remove length
     });
 
     // verifies should handle empty headers object
     test('should handle empty headers object', () => {
       const result = buildCleanHeaders({}, 'GET', null);
-      expect(Object.keys(result)).toHaveLength(0);
+      expect(Object.keys(result)).toHaveLength(0); // result should stay empty
     });
 
     // verifies should not mutate original headers
     test('should not mutate original headers', () => {
       const original = { ...originalHeaders };
       buildCleanHeaders(originalHeaders, 'GET', null);
-      expect(originalHeaders).toEqual(original);
+      expect(originalHeaders).toEqual(original); // verify immutability
     });
 
     // verifies should default to GET when method is invalid
     test('should default to GET when method is invalid', () => {
       const result = buildCleanHeaders(originalHeaders, 123, null);
-      expect(result['content-length']).toBeUndefined();
-      expect(result['host']).toBeUndefined();
+      expect(result['content-length']).toBeUndefined(); // invalid method defaults to GET
+      expect(result['host']).toBeUndefined(); // host still removed
     });
   });
 
@@ -157,8 +157,8 @@ describe('HTTP Utilities', () => {
       const data = { message: 'Success' };
       sendJsonResponse(mockRes, 200, data);
       
-      expect(mockRes.status).toHaveBeenCalledWith(200);
-      expect(mockRes.json).toHaveBeenCalledWith(data);
+      expect(mockRes.status).toHaveBeenCalledWith(200); // status should match provided code
+      expect(mockRes.json).toHaveBeenCalledWith(data); // response payload should be sent
     });
 
     // verifies should handle error responses
@@ -166,8 +166,8 @@ describe('HTTP Utilities', () => {
       const errorData = { error: 'Not found' };
       sendJsonResponse(mockRes, 404, errorData);
       
-      expect(mockRes.status).toHaveBeenCalledWith(404);
-      expect(mockRes.json).toHaveBeenCalledWith(errorData);
+      expect(mockRes.status).toHaveBeenCalledWith(404); // error status is set
+      expect(mockRes.json).toHaveBeenCalledWith(errorData); // error payload returned
     });
   });
 
@@ -191,26 +191,26 @@ describe('HTTP Utilities', () => {
     // verifies should return header value when present
     test('should return header value when present', () => {
       const result = getRequiredHeader(mockReq, mockRes, 'authorization', 401, 'Missing auth');
-      expect(result).toBe('Bearer token123');
+      expect(result).toBe('Bearer token123'); // header retrieved in case-insensitive manner
       expect(mockRes.status).not.toHaveBeenCalled();
     });
 
     // verifies should send error response when header is missing
     test('should send error response when header is missing', () => {
       const result = getRequiredHeader(mockReq, mockRes, 'x-api-key', 401, 'Missing API key');
-      
-      expect(result).toBeNull();
-      expect(mockRes.status).toHaveBeenCalledWith(401);
-      expect(mockRes.json).toHaveBeenCalledWith({ error: 'Missing API key' });
+
+      expect(result).toBeNull(); // missing header returns null
+      expect(mockRes.status).toHaveBeenCalledWith(401); // sends unauthorized code
+      expect(mockRes.json).toHaveBeenCalledWith({ error: 'Missing API key' }); // payload explains missing key
     });
 
     // verifies should handle malformed request object
     test('should handle malformed request object', () => {
       const malformedReq = {};
       const result = getRequiredHeader(malformedReq, mockRes, 'authorization', 401, 'Missing auth');
-      
-      expect(result).toBeNull();
-      expect(mockRes.status).toHaveBeenCalledWith(401);
+
+      expect(result).toBeNull(); // missing headers should cause null return
+      expect(mockRes.status).toHaveBeenCalledWith(401); // unauthorized status used for missing header
     });
 
     // verifies should handle undefined headers
@@ -218,14 +218,14 @@ describe('HTTP Utilities', () => {
       const reqWithoutHeaders = { headers: undefined };
       const result = getRequiredHeader(reqWithoutHeaders, mockRes, 'authorization', 401, 'Missing auth');
 
-      expect(result).toBeNull();
-      expect(mockRes.status).toHaveBeenCalledWith(401);
+      expect(result).toBeNull(); // undefined headers result in null
+      expect(mockRes.status).toHaveBeenCalledWith(401); // still unauthorized
     });
 
     // verifies should retrieve header regardless of case
     test('should retrieve header regardless of case', () => {
       const result = getRequiredHeader(mockReq, mockRes, 'Authorization', 401, 'Missing auth');
-      expect(result).toBe('Bearer token123');
+      expect(result).toBe('Bearer token123'); // case-insensitive header check
     });
 
     // verifies should handle errors during header processing
@@ -239,9 +239,9 @@ describe('HTTP Utilities', () => {
       
       const result = getRequiredHeader(req, res, 'authorization', 401, 'Missing auth');
       
-      expect(result).toBeNull();
-      expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' });
+      expect(result).toBeNull(); // failure should return null
+      expect(res.status).toHaveBeenCalledWith(500); // error status for processing issue
+      expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' }); // generic error body
     });
   });
 

--- a/tests/unit/index.exports.test.js
+++ b/tests/unit/index.exports.test.js
@@ -6,8 +6,8 @@ const indexExports = require('../index');
 describe('Index Exports', () => {
   // verifies should include new response utility exports
   test('should include new response utility exports', () => {
-    expect(indexExports.sendValidationError).toBeDefined();
-    expect(indexExports.sendAuthError).toBeDefined();
-    expect(indexExports.sendServerError).toBeDefined();
+    expect(indexExports.sendValidationError).toBeDefined(); // verify export exists
+    expect(indexExports.sendAuthError).toBeDefined(); // verify export exists
+    expect(indexExports.sendServerError).toBeDefined(); // verify export exists
   });
 });

--- a/tests/unit/logging-utils.test.js
+++ b/tests/unit/logging-utils.test.js
@@ -12,45 +12,45 @@ describe('Logging Utilities', () => {
   describe('logFunctionStart', () => {
     test('should log string input', () => {
       logFunctionStart('testStart', 'value');
-      expect(mockConsole.log).toHaveBeenCalledWith('testStart is running with value');
+      expect(mockConsole.log).toHaveBeenCalledWith('testStart is running with value'); // string parameter logged as expected
     });
 
     test('should log null input', () => {
       logFunctionStart('testStart', null);
-      expect(mockConsole.log).toHaveBeenCalledWith('testStart is running with null');
+      expect(mockConsole.log).toHaveBeenCalledWith('testStart is running with null'); // null parameter logged explicitly
     });
 
     test('should log object input', () => {
       const obj = { a: 1 };
       logFunctionStart('testStart', obj);
-      expect(mockConsole.log).toHaveBeenCalledWith(`testStart is running with ${JSON.stringify(obj)}`);
+      expect(mockConsole.log).toHaveBeenCalledWith(`testStart is running with ${JSON.stringify(obj)}`); // object converted to JSON
     });
 
     test('should handle circular reference input', () => {
       const circ = {}; circ.self = circ; // create circular object for test
       logFunctionStart('testStart', circ); // call with circular object
-      expect(mockConsole.log).toHaveBeenCalledWith('testStart is running with [unserializable]');
-      expect(qerrors).toHaveBeenCalledWith(expect.any(Error), 'logFunctionStart', { input: circ });
+      expect(mockConsole.log).toHaveBeenCalledWith('testStart is running with [unserializable]'); // fallback message for circular objects
+      expect(qerrors).toHaveBeenCalledWith(expect.any(Error), 'logFunctionStart', { input: circ }); // logged via qerrors
     });
   });
 
   describe('logFunctionResult', () => {
     test('should log undefined result', () => {
       logFunctionResult('testResult', undefined);
-      expect(mockConsole.log).toHaveBeenCalledWith('testResult is returning undefined');
+      expect(mockConsole.log).toHaveBeenCalledWith('testResult is returning undefined'); // explicit undefined logged
     });
 
     test('should log object result', () => {
       const obj = { b: 2 };
       logFunctionResult('testResult', obj);
-      expect(mockConsole.log).toHaveBeenCalledWith(`testResult is returning ${JSON.stringify(obj)}`);
+      expect(mockConsole.log).toHaveBeenCalledWith(`testResult is returning ${JSON.stringify(obj)}`); // object serialized correctly
     });
 
     test('should handle circular reference result', () => {
       const circ = {}; circ.self = circ; // create circular object result
       logFunctionResult('testResult', circ); // call with circular object
-      expect(mockConsole.log).toHaveBeenCalledWith('testResult is returning [unserializable]');
-      expect(qerrors).toHaveBeenCalledWith(expect.any(Error), 'logFunctionResult', { result: circ });
+      expect(mockConsole.log).toHaveBeenCalledWith('testResult is returning [unserializable]'); // fallback for circular
+      expect(qerrors).toHaveBeenCalledWith(expect.any(Error), 'logFunctionResult', { result: circ }); // error logged
     });
   });
 
@@ -58,15 +58,15 @@ describe('Logging Utilities', () => {
     test('should log error and return false by default', () => {
       const err = new Error('fail');
       const result = logFunctionError(err, 'testError', { ctx: true });
-      expect(qerrors).toHaveBeenCalledWith(err, 'testError', { ctx: true });
-      expect(mockConsole.log).toHaveBeenCalledWith('testError has run resulting in a final value of failure');
-      expect(result).toBe(false);
+      expect(qerrors).toHaveBeenCalledWith(err, 'testError', { ctx: true }); // qerrors logs context
+      expect(mockConsole.log).toHaveBeenCalledWith('testError has run resulting in a final value of failure'); // console output matches pattern
+      expect(result).toBe(false); // default return value is false
     });
 
     test('should support custom default return', () => {
       const err = new Error('oops');
       const result = logFunctionError(err, 'testError', {}, 'fallback');
-      expect(result).toBe('fallback');
+      expect(result).toBe('fallback'); // custom default value returned
     });
   });
 });

--- a/tests/unit/response-utils.test.js
+++ b/tests/unit/response-utils.test.js
@@ -21,8 +21,8 @@ describe('Response Utilities', () => {
       const payload = { success: true };
       sendJsonResponse(mockRes, 201, payload);
 
-      expect(mockRes.status).toHaveBeenCalledWith(201);
-      expect(mockRes.json).toHaveBeenCalledWith(payload);
+      expect(mockRes.status).toHaveBeenCalledWith(201); // status should match argument
+      expect(mockRes.json).toHaveBeenCalledWith(payload); // json payload returned
     });
 
     // verifies should handle invalid response objects gracefully
@@ -30,7 +30,7 @@ describe('Response Utilities', () => {
       const badRes = {}; // missing status/json
       sendJsonResponse(badRes, 200, { ok: true });
 
-      expect(qerrors).toHaveBeenCalled();
+      expect(qerrors).toHaveBeenCalled(); // error logged for bad response object
     });
 
     // verifies should work when status does not chain
@@ -38,8 +38,8 @@ describe('Response Utilities', () => {
       const nonChainRes = { status: jest.fn(), json: jest.fn().mockReturnThis() };
       sendJsonResponse(nonChainRes, 202, { done: true });
 
-      expect(nonChainRes.status).toHaveBeenCalledWith(202);
-      expect(nonChainRes.json).toHaveBeenCalledWith({ done: true });
+      expect(nonChainRes.status).toHaveBeenCalledWith(202); // still sets status
+      expect(nonChainRes.json).toHaveBeenCalledWith({ done: true }); // response data
     });
   });
 
@@ -57,21 +57,21 @@ describe('Response Utilities', () => {
     test('should send validation error with default 400 code', () => {
       sendValidationError(mockRes, 'Invalid field', { field: 'name' });
 
-      expect(mockRes.status).toHaveBeenCalledWith(400);
-      expect(mockRes.json).toHaveBeenCalledWith({ error: 'Invalid field', field: 'name' });
+      expect(mockRes.status).toHaveBeenCalledWith(400); // default status
+      expect(mockRes.json).toHaveBeenCalledWith({ error: 'Invalid field', field: 'name' }); // payload includes field data
     });
 
     // verifies should allow custom status code
     test('should allow custom status code', () => {
       sendValidationError(mockRes, 'Too many', {}, 429);
 
-      expect(mockRes.status).toHaveBeenCalledWith(429);
+      expect(mockRes.status).toHaveBeenCalledWith(429); // custom code respected
     });
 
     // verifies should handle invalid response objects gracefully
     test('should handle invalid response objects gracefully', () => {
       sendValidationError({}, 'bad');
-      expect(qerrors).toHaveBeenCalled();
+      expect(qerrors).toHaveBeenCalled(); // invalid res triggers logging
     });
   });
 
@@ -81,14 +81,14 @@ describe('Response Utilities', () => {
       const res = { status: jest.fn().mockReturnThis(), json: jest.fn().mockReturnThis() };
       sendAuthError(res);
 
-      expect(res.status).toHaveBeenCalledWith(401);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Authentication required' });
+      expect(res.status).toHaveBeenCalledWith(401); // 401 for auth error
+      expect(res.json).toHaveBeenCalledWith({ error: 'Authentication required' }); // default message output
     });
 
     // verifies should handle invalid response objects gracefully
     test('should handle invalid response objects gracefully', () => {
       sendAuthError(undefined, 'nope');
-      expect(qerrors).toHaveBeenCalled();
+      expect(qerrors).toHaveBeenCalled(); // invalid response object logged
     });
   });
 
@@ -99,15 +99,15 @@ describe('Response Utilities', () => {
       const err = new Error('fail');
       sendServerError(res, 'Oops', err, 'context');
 
-      expect(qerrors).toHaveBeenCalledWith(err, 'sendServerError', { message: 'Oops', context: 'context' });
-      expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Oops' });
+      expect(qerrors).toHaveBeenCalledWith(err, 'sendServerError', { message: 'Oops', context: 'context' }); // original error forwarded
+      expect(res.status).toHaveBeenCalledWith(500); // sets status code to 500
+      expect(res.json).toHaveBeenCalledWith({ error: 'Oops' }); // send sanitized message
     });
 
     // verifies should handle invalid response objects gracefully
     test('should handle invalid response objects gracefully', () => {
       sendServerError(null, 'bad');
-      expect(qerrors).toHaveBeenCalled();
+      expect(qerrors).toHaveBeenCalled(); // invalid res logged
     });
 
     // verifies should handle JSON serialization failures
@@ -122,8 +122,8 @@ describe('Response Utilities', () => {
       sendJsonResponse(res, 200, { circular: {} });
       
       // Should attempt fallback after first failure
-      expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.status).toHaveBeenCalledWith(200); // first attempt uses requested status
+      expect(res.status).toHaveBeenCalledWith(500); // retry uses error status
       expect(qerrors).toHaveBeenCalled(); // Verify error logging occurred
     });
 
@@ -138,9 +138,9 @@ describe('Response Utilities', () => {
       
       sendJsonResponse(res, 200, { data: 'test' });
       
-      expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({ error: 'Response serialization failed' });
+      expect(res.status).toHaveBeenCalledWith(200); // normal response status first
+      expect(res.status).toHaveBeenCalledWith(500); // fallback on serialization error
+      expect(res.json).toHaveBeenCalledWith({ error: 'Response serialization failed' }); // send generic error JSON
     });
   });
 });

--- a/tests/unit/url.test.js
+++ b/tests/unit/url.test.js
@@ -8,121 +8,121 @@ describe('URL Utilities', () => {
   describe('ensureProtocol', () => {
     // verifies should add https to URL without protocol
     test('should add https to URL without protocol', () => {
-      expect(ensureProtocol('example.com')).toBe('https://example.com');
+      expect(ensureProtocol('example.com')).toBe('https://example.com'); // default to https
     });
 
     // verifies should preserve existing https protocol
     test('should preserve existing https protocol', () => {
-      expect(ensureProtocol('https://example.com')).toBe('https://example.com');
+      expect(ensureProtocol('https://example.com')).toBe('https://example.com'); // unchanged input
     });
 
     // verifies should preserve existing http protocol
     test('should preserve existing http protocol', () => {
-      expect(ensureProtocol('http://example.com')).toBe('http://example.com');
+      expect(ensureProtocol('http://example.com')).toBe('http://example.com'); // keep http
     });
 
     // verifies should handle case-insensitive protocols
     test('should handle case-insensitive protocols', () => {
-      expect(ensureProtocol('HTTP://example.com')).toBe('HTTP://example.com');
-      expect(ensureProtocol('HTTPS://example.com')).toBe('HTTPS://example.com');
+      expect(ensureProtocol('HTTP://example.com')).toBe('HTTP://example.com'); // should not alter case
+      expect(ensureProtocol('HTTPS://example.com')).toBe('HTTPS://example.com'); // protocol preserved
     });
 
     // verifies should return null for empty string
     test('should return null for empty string', () => {
-      expect(ensureProtocol('')).toBeNull();
+      expect(ensureProtocol('')).toBeNull(); // invalid string results in null
     });
 
     // verifies should return null for null input
     test('should return null for null input', () => {
-      expect(ensureProtocol(null)).toBeNull();
+      expect(ensureProtocol(null)).toBeNull(); // null returns null
     });
 
     // verifies should return null for non-string input
     test('should return null for non-string input', () => {
-      expect(ensureProtocol(123)).toBeNull();
-      expect(ensureProtocol({})).toBeNull();
+      expect(ensureProtocol(123)).toBeNull(); // non-string input returns null
+      expect(ensureProtocol({})).toBeNull(); // object input returns null
     });
 
     // verifies should handle URLs with paths
     test('should handle URLs with paths', () => {
-      expect(ensureProtocol('example.com/path')).toBe('https://example.com/path');
+      expect(ensureProtocol('example.com/path')).toBe('https://example.com/path'); // path retained
     });
 
     // verifies should handle URLs with query parameters
     test('should handle URLs with query parameters', () => {
-      expect(ensureProtocol('example.com/path?q=test')).toBe('https://example.com/path?q=test');
+      expect(ensureProtocol('example.com/path?q=test')).toBe('https://example.com/path?q=test'); // query preserved
     });
 
     // verifies should trim whitespace and add https
     test('should trim whitespace and add https', () => {
-      expect(ensureProtocol('  example.com  ')).toBe('https://example.com');
+      expect(ensureProtocol('  example.com  ')).toBe('https://example.com'); // trims whitespace
     });
   });
 
   describe('normalizeUrlOrigin', () => {
     // verifies should normalize URL to lowercase origin
     test('should normalize URL to lowercase origin', () => {
-      expect(normalizeUrlOrigin('HTTPS://Example.Com/path')).toBe('https://example.com');
+      expect(normalizeUrlOrigin('HTTPS://Example.Com/path')).toBe('https://example.com'); // converts host to lowercase
     });
 
     // verifies should handle URL without protocol
     test('should handle URL without protocol', () => {
-      expect(normalizeUrlOrigin('Example.Com/path')).toBe('https://example.com');
+      expect(normalizeUrlOrigin('Example.Com/path')).toBe('https://example.com'); // protocol added when missing
     });
 
     // verifies should preserve port numbers
     test('should preserve port numbers', () => {
-      expect(normalizeUrlOrigin('https://example.com:8080/path')).toBe('https://example.com:8080');
+      expect(normalizeUrlOrigin('https://example.com:8080/path')).toBe('https://example.com:8080'); // port retained
     });
 
     // verifies should return null for invalid URLs
     test('should return null for invalid URLs', () => {
-      expect(normalizeUrlOrigin('')).toBeNull();
-      expect(normalizeUrlOrigin(null)).toBeNull();
+      expect(normalizeUrlOrigin('')).toBeNull(); // invalid string returns null
+      expect(normalizeUrlOrigin(null)).toBeNull(); // null also returns null
     });
 
     // verifies should handle complex URLs
     test('should handle complex URLs', () => {
-      expect(normalizeUrlOrigin('HTTPS://API.Example.Com:443/v1/users?id=123')).toBe('https://api.example.com');
+      expect(normalizeUrlOrigin('HTTPS://API.Example.Com:443/v1/users?id=123')).toBe('https://api.example.com'); // complex URL normalized
     });
   });
 
   describe('stripProtocol', () => {
     // verifies should remove https protocol
     test('should remove https protocol', () => {
-      expect(stripProtocol('https://example.com')).toBe('example.com');
+      expect(stripProtocol('https://example.com')).toBe('example.com'); // remove https scheme
     });
 
     // verifies should remove http protocol
     test('should remove http protocol', () => {
-      expect(stripProtocol('http://example.com')).toBe('example.com');
+      expect(stripProtocol('http://example.com')).toBe('example.com'); // remove http scheme
     });
 
     // verifies should remove trailing slash
     test('should remove trailing slash', () => {
-      expect(stripProtocol('https://example.com/')).toBe('example.com');
+      expect(stripProtocol('https://example.com/')).toBe('example.com'); // trailing slash removed
     });
 
     // verifies should handle case-insensitive protocols
     test('should handle case-insensitive protocols', () => {
-      expect(stripProtocol('HTTPS://example.com')).toBe('example.com');
-      expect(stripProtocol('HTTP://example.com')).toBe('example.com');
+      expect(stripProtocol('HTTPS://example.com')).toBe('example.com'); // handle uppercase
+      expect(stripProtocol('HTTP://example.com')).toBe('example.com'); // handle uppercase
     });
 
     // verifies should preserve paths and query parameters
     test('should preserve paths and query parameters', () => {
-      expect(stripProtocol('https://example.com/path?q=test')).toBe('example.com/path?q=test');
+      expect(stripProtocol('https://example.com/path?q=test')).toBe('example.com/path?q=test'); // preserve path and query
     });
 
     // verifies should handle URLs without protocol
     test('should handle URLs without protocol', () => {
-      expect(stripProtocol('example.com')).toBe('example.com');
+      expect(stripProtocol('example.com')).toBe('example.com'); // input without protocol unchanged
     });
 
     // verifies should handle error cases gracefully
     test('should handle error cases gracefully', () => {
       // Should return original input if processing fails
-      expect(typeof stripProtocol('test')).toBe('string');
+      expect(typeof stripProtocol('test')).toBe('string'); // error handling returns string
     });
   });
 
@@ -130,7 +130,7 @@ describe('URL Utilities', () => {
     // verifies should parse URL into base and endpoint
     test('should parse URL into base and endpoint', () => {
       const result = parseUrlParts('example.com/api/users?id=123');
-      expect(result).toEqual({
+      expect(result).toEqual({ // ensure base and endpoint returned correctly
         baseUrl: 'https://example.com',
         endpoint: '/api/users?id=123'
       });
@@ -139,7 +139,7 @@ describe('URL Utilities', () => {
     // verifies should handle URL with existing protocol
     test('should handle URL with existing protocol', () => {
       const result = parseUrlParts('https://api.example.com/v1/users');
-      expect(result).toEqual({
+      expect(result).toEqual({ // existing protocol preserved
         baseUrl: 'https://api.example.com',
         endpoint: '/v1/users'
       });
@@ -148,7 +148,7 @@ describe('URL Utilities', () => {
     // verifies should handle root path
     test('should handle root path', () => {
       const result = parseUrlParts('example.com/');
-      expect(result).toEqual({
+      expect(result).toEqual({ // handles root path
         baseUrl: 'https://example.com',
         endpoint: '/'
       });
@@ -157,7 +157,7 @@ describe('URL Utilities', () => {
     // verifies should handle URL without path
     test('should handle URL without path', () => {
       const result = parseUrlParts('example.com');
-      expect(result).toEqual({
+      expect(result).toEqual({ // handles missing path
         baseUrl: 'https://example.com',
         endpoint: '/'
       });
@@ -165,14 +165,14 @@ describe('URL Utilities', () => {
 
     // verifies should return null for invalid URLs
     test('should return null for invalid URLs', () => {
-      expect(parseUrlParts('')).toBeNull();
-      expect(parseUrlParts(null)).toBeNull();
+      expect(parseUrlParts('')).toBeNull(); // invalid input returns null
+      expect(parseUrlParts(null)).toBeNull(); // null returns null
     });
 
     // verifies should handle URLs with ports
     test('should handle URLs with ports', () => {
       const result = parseUrlParts('example.com:8080/api');
-      expect(result).toEqual({
+      expect(result).toEqual({ // port support
         baseUrl: 'https://example.com:8080',
         endpoint: '/api'
       });
@@ -181,7 +181,7 @@ describe('URL Utilities', () => {
     // verifies should handle complex query parameters
     test('should handle complex query parameters', () => {
       const result = parseUrlParts('api.example.com/search?q=test&limit=10&sort=name');
-      expect(result).toEqual({
+      expect(result).toEqual({ // complex query parameters retained
         baseUrl: 'https://api.example.com',
         endpoint: '/search?q=test&limit=10&sort=name'
       });

--- a/tests/unit/validation.test.js
+++ b/tests/unit/validation.test.js
@@ -20,8 +20,8 @@ describe('Validation Utilities', () => {
       const obj = { name: 'John', email: 'john@example.com', age: 30 };
       const result = requireFields(obj, ['name', 'email', 'age'], mockRes);
       
-      expect(result).toBe(true);
-      expect(mockRes.status).not.toHaveBeenCalled();
+      expect(result).toBe(true); // all fields present
+      expect(mockRes.status).not.toHaveBeenCalled(); // no error sent
     });
 
     // verifies should return false and send error for missing fields
@@ -29,8 +29,8 @@ describe('Validation Utilities', () => {
       const obj = { name: 'John', age: 30 };
       const result = requireFields(obj, ['name', 'email', 'age'], mockRes);
       
-      expect(result).toBe(false);
-      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(result).toBe(false); // missing email triggers failure
+      expect(mockRes.status).toHaveBeenCalledWith(400); // returns bad request
       expect(mockRes.json).toHaveBeenCalledWith({
         error: 'Missing required fields',
         missing: ['email']
@@ -42,8 +42,8 @@ describe('Validation Utilities', () => {
       const obj = { name: 'John' };
       const result = requireFields(obj, ['name', 'email', 'age'], mockRes);
       
-      expect(result).toBe(false);
-      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(result).toBe(false); // multiple fields missing
+      expect(mockRes.status).toHaveBeenCalledWith(400); // status set once
       expect(mockRes.json).toHaveBeenCalledWith({
         error: 'Missing required fields',
         missing: ['email', 'age']
@@ -55,8 +55,8 @@ describe('Validation Utilities', () => {
       const obj = { name: '', email: null, age: 0, active: false };
       const result = requireFields(obj, ['name', 'email', 'age', 'active'], mockRes);
       
-      expect(result).toBe(false);
-      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(result).toBe(false); // falsy values considered missing
+      expect(mockRes.status).toHaveBeenCalledWith(400); // still 400 response
       expect(mockRes.json).toHaveBeenCalledWith({
         error: 'Missing required fields',
         missing: ['name', 'email', 'age', 'active']
@@ -68,8 +68,8 @@ describe('Validation Utilities', () => {
       const obj = {};
       const result = requireFields(obj, ['name'], mockRes);
       
-      expect(result).toBe(false);
-      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(result).toBe(false); // empty object fails validation
+      expect(mockRes.status).toHaveBeenCalledWith(400); // should send 400
     });
 
     // verifies should handle empty required fields array
@@ -77,16 +77,16 @@ describe('Validation Utilities', () => {
       const obj = { name: 'John' };
       const result = requireFields(obj, [], mockRes);
       
-      expect(result).toBe(true);
-      expect(mockRes.status).not.toHaveBeenCalled();
+      expect(result).toBe(true); // no required fields means success
+      expect(mockRes.status).not.toHaveBeenCalled(); // no error when none required
     });
 
     // verifies should handle undefined object gracefully
     test('should handle undefined object gracefully', () => {
       const result = requireFields(undefined, ['name'], mockRes);
       
-      expect(result).toBe(false);
-      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(result).toBe(false); // invalid obj returns false
+      expect(mockRes.status).toHaveBeenCalledWith(500); // internal error status
       expect(mockRes.json).toHaveBeenCalledWith({
         error: 'Internal validation error'
       });
@@ -96,8 +96,8 @@ describe('Validation Utilities', () => {
     test('should handle null object gracefully', () => {
       const result = requireFields(null, ['name'], mockRes);
       
-      expect(result).toBe(false);
-      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(result).toBe(false); // null object also invalid
+      expect(mockRes.status).toHaveBeenCalledWith(500); // internal error status
     });
 
     // verifies should accept truthy values
@@ -111,8 +111,8 @@ describe('Validation Utilities', () => {
       };
       const result = requireFields(obj, ['name', 'count', 'active', 'data', 'config'], mockRes);
       
-      expect(result).toBe(true);
-      expect(mockRes.status).not.toHaveBeenCalled();
+      expect(result).toBe(true); // valid fields accepted
+      expect(mockRes.status).not.toHaveBeenCalled(); // no error
     });
 
     // verifies should handle invalid requiredFields parameter
@@ -120,9 +120,9 @@ describe('Validation Utilities', () => {
       const obj = { name: 'John' };
       const result = requireFields(obj, null, mockRes);
       
-      expect(result).toBe(false);
-      expect(mockRes.status).toHaveBeenCalledWith(500);
-      expect(mockRes.json).toHaveBeenCalledWith({ error: 'Internal validation error' });
+      expect(result).toBe(false); // invalid requiredFields parameter
+      expect(mockRes.status).toHaveBeenCalledWith(500); // internal error for invalid param
+      expect(mockRes.json).toHaveBeenCalledWith({ error: 'Internal validation error' }); // send generic message
     });
 
     // verifies should handle non-array requiredFields parameter
@@ -130,18 +130,18 @@ describe('Validation Utilities', () => {
       const obj = { name: 'John' };
       const result = requireFields(obj, 'name', mockRes);
       
-      expect(result).toBe(false);
-      expect(mockRes.status).toHaveBeenCalledWith(500);
-      expect(mockRes.json).toHaveBeenCalledWith({ error: 'Internal validation error' });
+      expect(result).toBe(false); // non-array requiredFields not allowed
+      expect(mockRes.status).toHaveBeenCalledWith(500); // internal error
+      expect(mockRes.json).toHaveBeenCalledWith({ error: 'Internal validation error' }); // error message
     });
 
     // verifies should handle invalid obj parameter
     test('should handle invalid obj parameter', () => {
       const result = requireFields(null, ['name'], mockRes);
       
-      expect(result).toBe(false);
-      expect(mockRes.status).toHaveBeenCalledWith(500);
-      expect(mockRes.json).toHaveBeenCalledWith({ error: 'Internal validation error' });
+      expect(result).toBe(false); // null object again invalid
+      expect(mockRes.status).toHaveBeenCalledWith(500); // internal error
+      expect(mockRes.json).toHaveBeenCalledWith({ error: 'Internal validation error' }); // respond with generic
     });
   });
 });

--- a/tests/unit/views.test.js
+++ b/tests/unit/views.test.js
@@ -20,9 +20,9 @@ describe('View Utilities', () => {
     test('should render view successfully', () => {
       renderView(mockRes, 'dashboard', 'Dashboard Error');
       
-      expect(mockRes.render).toHaveBeenCalledWith('dashboard');
-      expect(mockRes.status).not.toHaveBeenCalled();
-      expect(mockRes.send).not.toHaveBeenCalled();
+      expect(mockRes.render).toHaveBeenCalledWith('dashboard'); // view rendered successfully
+      expect(mockRes.status).not.toHaveBeenCalled(); // no error status
+      expect(mockRes.send).not.toHaveBeenCalled(); // no html fallback sent
     });
 
     // verifies should send error page when rendering fails
@@ -34,11 +34,11 @@ describe('View Utilities', () => {
       
       renderView(mockRes, 'nonexistent', 'Template Error');
       
-      expect(mockRes.render).toHaveBeenCalledWith('nonexistent');
-      expect(mockRes.status).toHaveBeenCalledWith(500);
-      expect(mockRes.send).toHaveBeenCalledWith(expect.stringContaining('Template Error'));
-      expect(mockRes.send).toHaveBeenCalledWith(expect.stringContaining('Template not found'));
-      expect(mockRes.send).toHaveBeenCalledWith(expect.stringContaining('Return to Home'));
+      expect(mockRes.render).toHaveBeenCalledWith('nonexistent'); // attempted render of missing template
+      expect(mockRes.status).toHaveBeenCalledWith(500); // send server error
+      expect(mockRes.send).toHaveBeenCalledWith(expect.stringContaining('Template Error')); // error title included
+      expect(mockRes.send).toHaveBeenCalledWith(expect.stringContaining('Template not found')); // original message included
+      expect(mockRes.send).toHaveBeenCalledWith(expect.stringContaining('Return to Home')); // navigation hint included
     });
 
     // verifies should handle missing send method gracefully
@@ -52,9 +52,9 @@ describe('View Utilities', () => {
 
       expect(() => {
         renderView(mockRes, 'view', 'Error Title');
-      }).not.toThrow();
+      }).not.toThrow(); // should handle missing send gracefully
 
-      expect(mockRes.status).not.toHaveBeenCalled();
+      expect(mockRes.status).not.toHaveBeenCalled(); // status not modified
     });
 
     // verifies should include error message in error page
@@ -67,9 +67,9 @@ describe('View Utilities', () => {
       renderView(mockRes, 'failing-view', 'Custom Error Title');
       
       const sentContent = mockRes.send.mock.calls[0][0];
-      expect(sentContent).toContain('Custom Error Title');
-      expect(sentContent).toContain('Custom error message');
-      expect(sentContent).toContain('failing-view');
+      expect(sentContent).toContain('Custom Error Title'); // title appears in output
+      expect(sentContent).toContain('Custom error message'); // message sanitized
+      expect(sentContent).toContain('failing-view'); // view name included
     });
 
     // verifies should escape error message for safe HTML
@@ -82,7 +82,7 @@ describe('View Utilities', () => {
       renderView(mockRes, 'script-view', 'Script Error');
 
       const sentContent = mockRes.send.mock.calls[0][0];
-      expect(sentContent).toContain('&lt;script&gt;alert("x")&lt;/script&gt;');
+      expect(sentContent).toContain('&lt;script&gt;alert("x")&lt;/script&gt;'); // script tags escaped
     });
 
     // verifies should handle different view names
@@ -97,7 +97,7 @@ describe('View Utilities', () => {
         };
         
         renderView(freshMockRes, viewName, 'Error');
-        expect(freshMockRes.render).toHaveBeenCalledWith(viewName);
+        expect(freshMockRes.render).toHaveBeenCalledWith(viewName); // each view renders once
       });
     });
   });
@@ -122,7 +122,7 @@ describe('View Utilities', () => {
     test('should register route with correct path and handler', () => {
       registerViewRoute('/dashboard', 'dashboard', 'Dashboard Error');
       
-      expect(mockApp.get).toHaveBeenCalledWith('/dashboard', expect.any(Function));
+      expect(mockApp.get).toHaveBeenCalledWith('/dashboard', expect.any(Function)); // route registered
     });
 
     // verifies should create handler that calls renderView
@@ -138,7 +138,7 @@ describe('View Utilities', () => {
       };
       
       handler(mockReq, mockRes);
-      expect(mockRes.render).toHaveBeenCalledWith('profile');
+      expect(mockRes.render).toHaveBeenCalledWith('profile'); // handler triggers render
     });
 
     // verifies should handle app registration errors gracefully
@@ -150,7 +150,7 @@ describe('View Utilities', () => {
       // Should not throw error
       expect(() => {
         registerViewRoute('/failing-route', 'view', 'Error');
-      }).not.toThrow();
+      }).not.toThrow(); // registration error swallowed
     });
 
     // verifies should handle missing global app
@@ -160,7 +160,7 @@ describe('View Utilities', () => {
       // Should not throw error
       expect(() => {
         registerViewRoute('/test', 'test', 'Test Error');
-      }).not.toThrow();
+      }).not.toThrow(); // missing global.app handled
     });
 
     // verifies should register multiple routes
@@ -175,10 +175,10 @@ describe('View Utilities', () => {
         registerViewRoute(path, view, title);
       });
       
-      expect(mockApp.get).toHaveBeenCalledTimes(3);
-      expect(mockApp.get).toHaveBeenCalledWith('/home', expect.any(Function));
-      expect(mockApp.get).toHaveBeenCalledWith('/about', expect.any(Function));
-      expect(mockApp.get).toHaveBeenCalledWith('/contact', expect.any(Function));
+      expect(mockApp.get).toHaveBeenCalledTimes(3); // three routes registered
+      expect(mockApp.get).toHaveBeenCalledWith('/home', expect.any(Function)); // home route
+      expect(mockApp.get).toHaveBeenCalledWith('/about', expect.any(Function)); // about route
+      expect(mockApp.get).toHaveBeenCalledWith('/contact', expect.any(Function)); // contact route
     });
   });
 });


### PR DESCRIPTION
## Summary
- add inline comments throughout tests clarifying assertions and setup
- note test runner details and jest event handlers in run-tests.js
- annotate global setup helpers

## Testing
- `node tests/run-tests.js >/tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_b_684ce80f87888322bea0db19f12940f8