### PR TITLE
Improve auth module docs

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -15,6 +15,17 @@
  * Passport.js is a popular authentication middleware for Express.js that supports
  * multiple authentication strategies (local, OAuth, SAML, etc.). These utilities
  * work with Passport's standard API and patterns.
+ *
+ * GLOBAL PASSPORT ACCESS:
+ * These utilities read `global.passport` to inspect configured strategies.
+ * Storing the Passport instance globally lets any module check auth status
+ * without requiring dependency injection, which keeps helpers decoupled from
+ * Express initialization.
+ *
+ * FAIL-CLOSED RATIONALE:
+ * Any problem or misconfiguration should deny access rather than grant it.
+ * Returning `false` on errors prevents unauthorized exposure when the
+ * authentication state is uncertain.
  */
 
 const { qerrors } = require('qerrors'); // integrate central error tracking
@@ -68,7 +79,7 @@ function logAuthOperation(functionName, input, result) {
  */
 function checkPassportAuth(req) {
   try { // begin auth state evaluation
-    const isAuthenticated = !!(req.isAuthenticated && req.isAuthenticated()); // call Passport isAuthenticated when available and coerce to boolean
+    const isAuthenticated = !!(req.isAuthenticated && req.isAuthenticated()); // call isAuthenticated if present else false then coerce to boolean
 
     logAuthOperation('checkPassportAuth', req?.user?.username || 'guest', isAuthenticated); // record the check for auditing
     return isAuthenticated; // return computed auth state
@@ -117,7 +128,7 @@ function checkPassportAuth(req) {
 function hasGithubStrategy() {
   try { // attempt strategy detection
     const passportObj = global.passport; // get Passport instance from global scope
-    if (!passportObj || !passportObj._strategies) { // confirm strategies registry exists
+    if (!passportObj || !passportObj._strategies) { // confirm global passport and strategies registry exist
       logAuthOperation('hasGithubStrategy', 'none', false); // note absence of GitHub strategy prerequisites
       return false; // fail closed if prerequisites missing
     }


### PR DESCRIPTION
## Summary
- elaborate passport global usage and fail-closed rationale in auth header comment
- clarify inline logic comments in checkPassportAuth and hasGithubStrategy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d4366b718832287f545358ffd2d1b