### PR TITLE
Clarify datetime fallback behavior

### DIFF
--- a/lib/datetime.js
+++ b/lib/datetime.js
@@ -21,7 +21,9 @@ const logger = require('./logger'); // structured logger
 /**
  * Helper function to validate if a Date object is valid
  * This centralizes the date validation logic used by multiple datetime functions
- * 
+ * Invalid inputs resolve to `false` so callers can return safe fallback values
+ * like "N/A" or "00:00:00" rather than throwing errors.
+ *
  * @param {Date} date - Date object to validate
  * @returns {boolean} True if date is valid, false otherwise
  */
@@ -65,6 +67,7 @@ function formatDateTime(dateString) {
   logger.debug(`formatDateTime is running with ${dateString}`); // persistent log
   try {
     // Handle empty or null input gracefully - common in optional date fields
+    // Returning "N/A" allows the UI to show a neutral value without crashing
     if (!dateString) { // short-circuit when input missing or blank
       console.log(`formatDateTime is returning N/A`); logger.debug(`formatDateTime is returning N/A`); // return neutral value
       return 'N/A'; // return neutral value so UIs know no date was provided
@@ -77,7 +80,7 @@ function formatDateTime(dateString) {
     // Handle invalid date strings using centralized validation
     if (!isValidDate(date)) { // reject invalid dates to avoid misleading output
       console.log(`formatDateTime is returning N/A`); logger.debug(`formatDateTime is returning N/A`);
-      return 'N/A';
+      return 'N/A'; // invalid date fallback prevents NaN in output
     }
     const formatted = date.toLocaleString(); // locale aware formatting for display
     console.log(`formatDateTime is returning ${formatted}`); logger.debug(`formatDateTime is returning ${formatted}`);
@@ -124,11 +127,17 @@ function formatDateTime(dateString) {
  * @param {string} startDateString - ISO date string for start time
  * @param {string} endDateString - ISO date string for end time (defaults to current time)
  * @returns {string} Duration in HH:MM:SS format or "00:00:00" if start date is invalid
- */
+ *
+ * INVALID INPUT POLICY:
+ * Empty or malformed start dates return "00:00:00" so downstream logic never
+ * receives NaN values. Invalid end dates throw so the caller can decide whether
+ * to default to "now" or surface an error.
+*/
 function formatDuration(startDateString, endDateString) {
   console.log(`formatDuration is running with ${startDateString} and ${endDateString}`); logger.debug(`formatDuration is running with ${startDateString} and ${endDateString}`);
   try {
     // Handle edge cases gracefully
+    // Empty start date yields zero duration so UIs show neutral value
     if (!startDateString || startDateString === '') { // guard against missing start time
       console.log(`formatDuration is returning 00:00:00`); logger.debug(`formatDuration is returning 00:00:00`);
       return '00:00:00';
@@ -152,9 +161,9 @@ function formatDuration(startDateString, endDateString) {
     const durationMs = Math.abs(endTime - startDate); // absolute diff handles reversed dates
 
     // Convert milliseconds to time components using standard time conversion
-    const hours = Math.floor(durationMs / (1000 * 60 * 60)); // convert to hours
-    const minutes = Math.floor((durationMs % (1000 * 60 * 60)) / (1000 * 60)); // leftover minutes
-    const seconds = Math.floor((durationMs % (1000 * 60)) / 1000); // leftover seconds
+    const hours = Math.floor(durationMs / (1000 * 60 * 60)); // 1000ms*60s*60m = 1hr
+    const minutes = Math.floor((durationMs % (1000 * 60 * 60)) / (1000 * 60)); // remainder from hours to minutes
+    const seconds = Math.floor((durationMs % (1000 * 60)) / 1000); // remainder from minutes to seconds
 
     // Format with zero-padding for consistent display (padStart ensures 2 digits)
     const formatted = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`; // pad for readability


### PR DESCRIPTION
## Summary
- clarify invalid date handling in `isValidDate`
- document fallback rationale in `formatDateTime`
- explain invalid input policy in `formatDuration`
- add inline notes for duration arithmetic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d436cb02c8322a5b13003050774a8