### PR TITLE
Align validation headers

### DIFF
--- a/lib/input-validation.js
+++ b/lib/input-validation.js
@@ -1,15 +1,12 @@
 
 /*
- * Input Validation Utility Module
- * 
- * This module provides common input validation functions used across multiple
- * modules to avoid code duplication and ensure consistent validation logic.
- * 
- * DESIGN PHILOSOPHY:
- * - Centralize validation logic to reduce duplication
- * - Provide consistent validation behavior across modules
- * - Return boolean values for simple integration
- * - Handle edge cases gracefully
+ * QGenUtils Core Input Validation
+ *
+ * Provides shared helpers for confirming objects, strings and Express
+ * response structures. These utilities support the library's fail-fast
+ * approach and return simple booleans so callers can branch quickly.
+ * Unexpected input is logged with qerrors to aid debugging without
+ * throwing exceptions.
  */
 
 const { qerrors } = require('qerrors'); // error logger used by validation helpers
@@ -51,7 +48,7 @@ function isValidObject(obj) {
  * @returns {boolean} True if valid string, false otherwise
  */
 function isValidString(str) {
-  return typeof str === 'string' && str.trim().length > 0; // trim ensures no whitespace-only strings
+  return typeof str === 'string' && str.trim().length > 0; // empty or whitespace strings are treated as missing
 }
 
 /**

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,20 +1,11 @@
 /*
- * Validation Utility Module
- * 
- * This module provides field validation utilities for API endpoints that need to
- * verify required fields are present and properly formatted before processing.
- * 
- * DESIGN PHILOSOPHY:
- * - Fail fast: Return detailed errors immediately when validation fails
- * - Developer friendly: List all missing fields at once (not just the first)
- * - Consistent responses: Use standardized error format across all endpoints
- * - Security minded: Validate input thoroughly before any processing
- * 
- * COMMON USE CASES:
- * - API endpoint parameter validation
- * - Form submission verification
- * - Database input sanitization
- * - User registration field checking
+ * QGenUtils Field Validation Utilities
+ *
+ * Centralizes checks that required request fields exist before processing
+ * continues. Following a fail-fast, fail-closed philosophy, any value that
+ * resolves to false (undefined, null, '', 0, false) is considered missing.
+ * Error responses are sent immediately using response-utils to stop further
+ * operations with invalid data and keep controller logic concise.
  */
 
 const { qerrors } = require('qerrors'); // central error logging integration
@@ -89,10 +80,10 @@ function requireFields(obj, requiredFields, res) {
       return false; // halt on invalid object
     }
 
-    const missingFields = requiredFields.filter(field => !obj[field]); // collect all missing or falsy fields
+    const missingFields = requiredFields.filter(field => !obj[field]); // collect fields with falsy values to force explicit input
 
-    if (missingFields.length > 0) { // if any field is missing respond immediately
-      sendValidationError(res, 'Missing required fields', { missing: missingFields }); // detailed failure feedback
+    if (missingFields.length > 0) { // fail fast when any field is missing
+      sendValidationError(res, 'Missing required fields', { missing: missingFields }); // immediate error stops processing
 
       console.log(`requireFields is returning false`); logger.debug(`requireFields is returning false`); // record validation failure
       return false; // signal failed validation


### PR DESCRIPTION
## Summary
- reword headers for validation modules for consistency
- document strict falsy checks and immediate failures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d436db5dc8322a322124127754bd4