### PR TITLE
Improve auth helper documentation

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -22,8 +22,8 @@ const logger = require('./logger'); // structured logger
 
 /**
  * Helper function to standardize authentication logging
- * This centralizes the logging pattern used by auth functions
- * 
+ * Centralization ensures consistent audit trails and easier debugging
+ *
  * @param {string} functionName - Name of the calling function
  * @param {*} input - Input parameter being processed
  * @param {*} result - Result being returned
@@ -35,11 +35,12 @@ function logAuthOperation(functionName, input, result) {
 
 /**
  * Check Passport authentication status
- * 
- * RATIONALE: Many routes need to verify if a user is authenticated before allowing
- * access. Passport.js adds an isAuthenticated() method to request objects, but
- * we need to handle cases where Passport isn't configured or requests bypass it.
- * 
+ *
+ * RATIONALE: Routes often gate protected resources behind authentication. Passport
+ * adds an isAuthenticated() method, but requests may omit the middleware or use
+ * alternate authentication flows. We defensively check and default to "deny" for
+ * security.
+ *
  * IMPLEMENTATION DECISIONS:
  * - Use double negation (!!) to convert truthy/falsy to strict boolean
  * - Check for existence of isAuthenticated method before calling it
@@ -51,7 +52,11 @@ function logAuthOperation(functionName, input, result) {
  * - Avoid throwing exceptions that could reveal authentication internals
  * - Log all authentication checks for security monitoring
  * - Handle edge cases where Passport middleware is missing
- * 
+ *
+ * TYPICAL USE CASES:
+ * - Gate route handlers to prevent anonymous access
+ * - Determine login state in view helpers for UI decisions
+ *
  * WHY DOUBLE NEGATION (!!):
  * req.isAuthenticated() might return truthy values that aren't strictly boolean.
  * !! converts any truthy value to true and any falsy value to false.
@@ -81,11 +86,11 @@ function checkPassportAuth(req) {
 
 /**
  * Detect presence of GitHub OAuth strategy
- * 
- * RATIONALE: Applications often need to conditionally show features based on
- * which authentication strategies are available. For example, only show "Login with GitHub"
- * button if GitHub OAuth is actually configured.
- * 
+ *
+ * RATIONALE: Some interfaces display GitHub login options only when OAuth is
+ * configured. Checking Passport's strategies lets the UI adapt to available
+ * authentication methods without exposing configuration details.
+ *
  * IMPLEMENTATION STRATEGY:
  * - Access Passport's internal strategy registry
  * - Check specifically for 'github' strategy by name
@@ -106,13 +111,19 @@ function checkPassportAuth(req) {
  * - Return false if Passport isn't available (graceful degradation)
  * - Return false if strategies object doesn't exist
  * - Log errors for debugging configuration issues
- * 
+ * - Fail closed so misconfiguration never exposes OAuth endpoints
+ *
+ * TYPICAL USE CASES:
+ * - Show or hide GitHub login buttons in templates
+ * - Determine if GitHub-based routes should be active
+ *
  * ALTERNATIVE APPROACHES CONSIDERED:
  * - Environment variable checking - rejected because config might be dynamic
  * - Strategy instantiation testing - rejected for performance reasons
  * - Configuration file parsing - rejected for coupling reasons
- * 
+ *
  * @returns {boolean} True if GitHub strategy is configured and available, false otherwise
+ * SECURITY: Function fails closed, returning false when configuration is uncertain
  */
 function hasGithubStrategy() {
   try { // attempt strategy detection


### PR DESCRIPTION
## Summary
- expand comment on logAuthOperation to clarify centralized logging rationale
- clarify checkPassportAuth's security focus and typical usage
- document hasGithubStrategy use cases and fail-closed behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684d437bb87c8322bd91fabba72ccaf1