### PR TITLE
Add logger docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -620,4 +620,14 @@ try {
 }
 ```
 
+## Logger
+
+The library exports a configured Winston logger instance. It rotates files daily using `winston-daily-rotate-file` and retains logs for two weeks. Use this logger to record application events or debugging details.
+
+```javascript
+const { logger } = require('qgenutils');
+
+logger.info('Utility initialized');
+```
+
 All functions include comprehensive logging and follow the fail-closed security model for production reliability.

--- a/USAGE.md
+++ b/USAGE.md
@@ -500,6 +500,14 @@ const duration = formatDuration(start, end);
 // Logs: "formatDuration is returning 02:00:00"
 ```
 
+You can also log your own messages using the provided logger instance. Logs rotate daily via `winston-daily-rotate-file`.
+
+```javascript
+const { logger } = require('qgenutils');
+
+logger.info('Server started');
+```
+
 ## Common Use Cases
 
 ### API Endpoint Template


### PR DESCRIPTION
## Summary
- document logger usage in API reference
- show how to log custom messages in usage guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684de614d9f88322b759c2fa982f0b10