### PR TITLE
Remove ESM example from API docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,8 +8,6 @@ QGenUtils provides utilities organized into focused modules. Each function follo
 
 ```javascript
 const utils = require('qgenutils');
-// or
-import utils from 'qgenutils';
 ```
 
 ## Authentication Module (`auth`)


### PR DESCRIPTION
## Summary
- strip ES module `import` example so docs only show `require`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684e07bb32388322be2e322a578f11fe