### PR TITLE
Remove import syntax from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ const utils = require('qgenutils');
 const { formatDateTime, calculateContentLength, ensureProtocol } = require('qgenutils');
 ```
 
-```javascript
-import utils from 'qgenutils'; // ESM default import example
-import { formatDateTime as fmtDate } from 'qgenutils'; // or named imports
-```
 
 ```javascript
 const { logger } = require('qgenutils'); // Winston logger instance


### PR DESCRIPTION
## Summary
- edit Quick Start section to only show CommonJS `require()` syntax

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684e07b67abc8322bcb2a44f0b4a8d1f