### PR TITLE
Remove ES module usage docs

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -15,11 +15,6 @@ const QGenUtils = require('qgenutils'); // import all utilities
 const { checkPassportAuth, requireFields, formatDateTime } = require('qgenutils');
 ```
 
-```javascript
-import QGenUtils from 'qgenutils'; // ESM style import for all utilities
-import { checkPassportAuth as checkAuth } from 'qgenutils'; // or named imports
-```
-
 ## Authentication Utilities
 
 ### `checkPassportAuth(req)`


### PR DESCRIPTION
## Summary
- remove ES Module import example from USAGE guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684e07b31bb08322a57f740d833ab2dd